### PR TITLE
[#23] Refactored calls to TreePath::create_path() for nicer API.

### DIFF
--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -20,14 +20,14 @@ impl Interpreter {
     }
 
     fn set_all_builtins(builtins: &mut PathTree<Command>) {
-        builtins.set_by_path(Command::from(ExitCommand), TreePath::create_path("exit"));
+        builtins.set_by_path(Command::from(ExitCommand), "exit");
         builtins.set_by_path(
             Command::from(CurrentTimeCommand),
-            TreePath::create_path("what time is it"),
+            "what time is it",
         );
         builtins.set_by_path(
             Command::from(WhatsYourNameCommand),
-            TreePath::create_path("what is your name"),
+            "what is your name",
         );
     }
 

--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -45,12 +45,11 @@ impl Interpreter {
 
         loop {
             let user_input = input::get_user_input(config::get_violet_prompt());
-            let pathified = TreePath::create_path(&user_input);
             match user_input.as_str() {
                 "" => continue,
-                _ => match self.builtin_commands.get_by_path(pathified.clone()) {
+                _ => match self.builtin_commands.get_by_path(user_input.as_str()) {
                     None => {
-                        println!("{}: command does not exist.", pathified.join(" "));
+                        println!("{}: command does not exist.", TreePath::prettify(user_input.as_str()));
                         continue;
                     }
                     Some(cmd) => {

--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -21,14 +21,8 @@ impl Interpreter {
 
     fn set_all_builtins(builtins: &mut PathTree<Command>) {
         builtins.set_by_path(Command::from(ExitCommand), "exit");
-        builtins.set_by_path(
-            Command::from(CurrentTimeCommand),
-            "what time is it",
-        );
-        builtins.set_by_path(
-            Command::from(WhatsYourNameCommand),
-            "what is your name",
-        );
+        builtins.set_by_path(Command::from(CurrentTimeCommand), "what time is it");
+        builtins.set_by_path(Command::from(WhatsYourNameCommand), "what is your name");
     }
 
     pub fn run_repl(&mut self) {
@@ -49,7 +43,10 @@ impl Interpreter {
                 "" => continue,
                 _ => match self.builtin_commands.get_by_path(user_input.as_str()) {
                     None => {
-                        println!("{}: command does not exist.", TreePath::prettify(user_input.as_str()));
+                        println!(
+                            "{}: command does not exist.",
+                            TreePath::prettify(user_input.as_str())
+                        );
                         continue;
                     }
                     Some(cmd) => {

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -24,9 +24,9 @@ where
         if path.is_empty() {
             panic!("ERROR: path to a node cannot be empty!");
         }
-        let path = TreePath::create_path(path);
 
         let the_hierarchy = TreePath::get_path_hierarchy(&path);
+        let path = TreePath::create_path(path);
         the_hierarchy
             .into_iter()
             .enumerate()
@@ -78,12 +78,10 @@ fn test_path_hierarchy() {
         "one two".to_string(),
         "one two three".to_string(),
     ];
-    let test_vec: Vec<String> = TreePath::create_path("one two three");
-    assert_eq!(expected, TreePath::get_path_hierarchy(&test_vec));
+    assert_eq!(expected, TreePath::get_path_hierarchy("one two three"));
 
     let expected: Vec<String> = vec!["one".to_string()];
-    let test_vec: Vec<String> = TreePath::create_path("one");
-    assert_eq!(expected, TreePath::get_path_hierarchy(&test_vec));
+    assert_eq!(expected, TreePath::get_path_hierarchy("one"));
 
     let expected: Vec<String> = vec![
         "そっか".to_string(),
@@ -93,8 +91,7 @@ fn test_path_hierarchy() {
         "そっか おふの $%?рашин /fourth .fifth".to_string(),
         "そっか おふの $%?рашин /fourth .fifth \\sixth".to_string(),
     ];
-    let test_vec: Vec<String> = TreePath::create_path("そっか おふの $%?рашин /fourth .fifth \\sixth");
-    assert_eq!(expected, TreePath::get_path_hierarchy(&test_vec));
+    assert_eq!(expected, TreePath::get_path_hierarchy("そっか おふの $%?рашин /fourth .fifth \\sixth"));
 }
 
 #[test]
@@ -205,7 +202,7 @@ fn check_empty_path_creation() {
         Vec::<String>::new(),
         TreePath::create_path(&String::from(""))
     );
-    assert_eq!(Vec::<String>::new(), TreePath::get_path_hierarchy(&vec![]));
+    assert_eq!(Vec::<String>::new(), TreePath::get_path_hierarchy(""));
 
     assert_eq!(false, test_tree.does_node_exist(""));
     assert_eq!(None, test_tree.get_by_path(""));

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -43,7 +43,8 @@ where
             })
     }
 
-    pub fn get_by_path(&self, path: Vec<String>) -> Option<&Node<T>> {
+    pub fn get_by_path(&self, path: &str) -> Option<&Node<T>> {
+        let path = TreePath::create_path(&path);
         if let Some(node_option) = self.tree.get(&path.join(" ")) {
             node_option.as_ref()
         } else {
@@ -129,35 +130,35 @@ fn test_tree_setters_and_getters() {
     );
     assert_eq!(
         None,
-        test_tree.get_by_path(TreePath::create_path(&"そっか".to_string()))
+        test_tree.get_by_path("そっか")
     );
     assert_eq!(
         None,
-        test_tree.get_by_path(TreePath::create_path(&"そっか おふの".to_string()))
+        test_tree.get_by_path("そっか おふの")
     );
     assert_eq!(
         None,
-        test_tree.get_by_path(TreePath::create_path(&"そっか おふの $%?рашин".to_string()))
+        test_tree.get_by_path("そっか おふの $%?рашин")
     );
     assert_eq!(
         None,
-        test_tree.get_by_path(TreePath::create_path(
-            &"そっか おふの $%?рашин /fourth".to_string()
-        ))
+        test_tree.get_by_path(
+            "そっか おふの $%?рашин /fourth"
+        )
     );
     assert_eq!(
         None,
-        test_tree.get_by_path(TreePath::create_path(
-            &"そっか おふの $%?рашин /fourth .fifth".to_string()
-        ))
+        test_tree.get_by_path(
+            "そっか おふの $%?рашин /fourth .fifth"
+        )
     );
     assert_eq!(
         Some(&Node {
             value: String::from("test garbage val")
         }),
-        test_tree.get_by_path(TreePath::create_path(
-            &"そっか おふの $%?рашин /fourth .fifth \\sixth".to_string()
-        ))
+        test_tree.get_by_path(
+            "そっか おふの $%?рашин /fourth .fifth \\sixth"
+        )
     );
 }
 
@@ -174,7 +175,7 @@ fn check_empty_path_creation() {
     assert_eq!(Vec::<String>::new(), TreePath::get_path_hierarchy(&vec![]));
 
     assert_eq!(false, test_tree.does_node_exist(vec![]));
-    assert_eq!(None, test_tree.get_by_path(vec![]));
+    assert_eq!(None, test_tree.get_by_path(""));
 }
 
 #[test]

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -58,15 +58,10 @@ where
     }
 
     pub fn does_node_exist(&self, path: &str) -> bool {
-        let path = TreePath::prettify(path);
-        if !self.tree.contains_key(&path) {
+        if !self.does_path_exist(&path) {
             false
-        }
-        else {
-            match self.get_by_path(&path) {
-                Some(_) => true,
-                None => false
-            }
+        } else {
+            self.get_by_path(&path).is_some()
         }
     }
 }
@@ -91,112 +86,76 @@ fn test_path_hierarchy() {
         "そっか おふの $%?рашин /fourth .fifth".to_string(),
         "そっか おふの $%?рашин /fourth .fifth \\sixth".to_string(),
     ];
-    assert_eq!(expected, TreePath::get_path_hierarchy("そっか おふの $%?рашин /fourth .fifth \\sixth"));
+    assert_eq!(
+        expected,
+        TreePath::get_path_hierarchy("そっか おふの $%?рашин /fourth .fifth \\sixth")
+    );
 }
 
 #[test]
 fn test_tree_setters_and_getters() {
     let mut test_tree = PathTree::new();
 
-    test_tree.set_by_path("test garbage val".to_string(), "そっか おふの $%?рашин /fourth .fifth \\sixth");
+    test_tree.set_by_path(
+        "test garbage val".to_string(),
+        "そっか おふの $%?рашин /fourth .fifth \\sixth",
+    );
+    assert_eq!(false, test_tree.does_node_exist("そっか"));
+    assert_eq!(true, test_tree.does_path_exist("そっか"));
+    assert_eq!(false, test_tree.does_node_exist("そっか おふの"));
+    assert_eq!(true, test_tree.does_path_exist("そっか おふの"));
+    assert_eq!(false, test_tree.does_node_exist("そっか おふの $%?рашин"));
+    assert_eq!(true, test_tree.does_path_exist("そっか おふの $%?рашин"));
     assert_eq!(
         false,
-        test_tree.does_node_exist("そっか")
+        test_tree.does_node_exist("そっか おふの $%?рашин /fourth")
     );
     assert_eq!(
         true,
-        test_tree.does_path_exist("そっか")
-    );
-    assert_eq!(
-        false,
-        test_tree.does_node_exist("そっか おふの")
-    );
-    assert_eq!(
-        true,
-        test_tree.does_path_exist("そっか おふの")
-    );
-    assert_eq!(
-        false,
-        test_tree.does_node_exist("そっか おふの $%?рашин")
-    );
-    assert_eq!(
-        true,
-        test_tree.does_path_exist("そっか おふの $%?рашин")
+        test_tree.does_path_exist("そっか おふの $%?рашин /fourth")
     );
     assert_eq!(
         false,
-        test_tree.does_node_exist(            
-            "そっか おふの $%?рашин /fourth"
-        )
+        test_tree.does_node_exist("そっか おふの $%?рашин /fourth .fifth")
     );
     assert_eq!(
         true,
-        test_tree.does_path_exist(            
-            "そっか おふの $%?рашин /fourth"
-        )
-    );
-    assert_eq!(
-        false,
-        test_tree.does_node_exist(
-            "そっか おふの $%?рашин /fourth .fifth"
-        )
+        test_tree.does_path_exist("そっか おふの $%?рашин /fourth .fifth")
     );
     assert_eq!(
         true,
-        test_tree.does_path_exist(
-            "そっか おふの $%?рашин /fourth .fifth"
-        )
+        test_tree.does_node_exist("そっか おふの $%?рашин /fourth .fifth \\sixth")
     );
     assert_eq!(
         true,
-        test_tree.does_node_exist(
-            "そっか おふの $%?рашин /fourth .fifth \\sixth"
-        )
+        test_tree.does_path_exist("そっか おふの $%?рашин /fourth .fifth \\sixth")
     );
+    assert_eq!(None, test_tree.get_by_path("そっか"));
+    assert_eq!(None, test_tree.get_by_path("そっか おふの"));
+    assert_eq!(None, test_tree.get_by_path("そっか おふの $%?рашин"));
     assert_eq!(
-        true,
-        test_tree.does_path_exist(
-            "そっか おふの $%?рашин /fourth .fifth \\sixth"
-        )
+        None,
+        test_tree.get_by_path("そっか おふの $%?рашин /fourth")
     );
     assert_eq!(
         None,
-        test_tree.get_by_path("そっか")
-    );
-    assert_eq!(
-        None,
-        test_tree.get_by_path("そっか おふの")
-    );
-    assert_eq!(
-        None,
-        test_tree.get_by_path("そっか おふの $%?рашин")
-    );
-    assert_eq!(
-        None,
-        test_tree.get_by_path(
-            "そっか おふの $%?рашин /fourth"
-        )
-    );
-    assert_eq!(
-        None,
-        test_tree.get_by_path(
-            "そっか おふの $%?рашин /fourth .fifth"
-        )
+        test_tree.get_by_path("そっか おふの $%?рашин /fourth .fifth")
     );
     assert_eq!(
         Some(&Node {
             value: String::from("test garbage val")
         }),
-        test_tree.get_by_path(
-            "そっか おふの $%?рашин /fourth .fifth \\sixth"
-        )
+        test_tree.get_by_path("そっか おふの $%?рашин /fourth .fifth \\sixth")
     );
 }
 
 #[test]
 fn check_empty_path_creation() {
     let mut test_tree = PathTree::new();
-    test_tree.set_by_path("test garbage val".to_string(), "そっか おふの $%?рашин /fourth .fifth \\sixth");
+    test_tree.set_by_path(
+        "test garbage val".to_string(),
+        "そっか おふの $%?рашин /fourth .fifth \\sixth",
+    );
 
     assert_eq!(
         Vec::<String>::new(),
@@ -222,22 +181,10 @@ fn test_pathing_works_with_untrimmed_paths() {
 
     test_tree.set_by_path("test garbage val".to_string(), path);
 
-    assert_eq!(
-        false,
-        test_tree.does_node_exist("something")
-    );
-    assert_eq!(
-        true,
-        test_tree.does_path_exist("something")
-    );
-    assert_eq!(
-        false,
-        test_tree.does_node_exist("something completely")
-    );
-    assert_eq!(
-        true,
-        test_tree.does_path_exist("something completely")
-    );
+    assert_eq!(false, test_tree.does_node_exist("something"));
+    assert_eq!(true, test_tree.does_path_exist("something"));
+    assert_eq!(false, test_tree.does_node_exist("something completely"));
+    assert_eq!(true, test_tree.does_path_exist("something completely"));
     assert_eq!(
         true,
         test_tree.does_node_exist("something completely bonkers")
@@ -247,24 +194,19 @@ fn test_pathing_works_with_untrimmed_paths() {
         test_tree.does_path_exist("something completely bonkers")
     );
 
-    assert_eq!(
-        None,
-        test_tree.get_by_path("something")
-    );
-    assert_eq!(
-        None,
-        test_tree.get_by_path("something completely")
-    );
+    assert_eq!(None, test_tree.get_by_path("something"));
+    assert_eq!(None, test_tree.get_by_path("something completely"));
     assert_eq!(
         Some(&Node {
             value: String::from("test garbage val")
         }),
-        test_tree.get_by_path(
-            "something completely bonkers"
-        )
+        test_tree.get_by_path("something completely bonkers")
     );
 
     assert_eq!(true, test_tree.tree.contains_key("something"));
     assert_eq!(true, test_tree.tree.contains_key("something completely"));
-    assert_eq!(true, test_tree.tree.contains_key("something completely bonkers"));
+    assert_eq!(
+        true,
+        test_tree.tree.contains_key("something completely bonkers")
+    );
 }

--- a/src/util/treepath.rs
+++ b/src/util/treepath.rs
@@ -21,4 +21,8 @@ impl TreePath {
 
         hierarchy
     }
+
+    pub fn prettify(path: &str) -> String {
+        TreePath::create_path(path).join(" ")
+    }
 }

--- a/src/util/treepath.rs
+++ b/src/util/treepath.rs
@@ -9,7 +9,8 @@ impl TreePath {
             .collect::<Vec<String>>()
     }
 
-    pub fn get_path_hierarchy(path: &[String]) -> Vec<String> {
+    pub fn get_path_hierarchy(path: &str) -> Vec<String> {
+        let path = TreePath::create_path(path);
         let mut current_path = String::new();
         let mut hierarchy: Vec<String> = vec![];
 


### PR DESCRIPTION
Now calls to create_path() are embedded into PathTree and the PathTree users don't have to call create_path themselves each time they use a PathTree method.