### PR TITLE
[#24] Refactored commands.rs to not depend on clone_uppercased().

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+use crate::util::string::clone_uppercased;
+
 const VIOLET_UNKNOWN: &str = "???";
 const VIOLET_VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
 const VIOLET_AUTHOR: Option<&'static str> = option_env!("CARGO_PKG_AUTHORS");
@@ -17,5 +19,5 @@ pub fn get_violet_prompt() -> String {
 }
 
 pub fn get_violet_name() -> String {
-    VIOLET_NAME.unwrap_or(VIOLET_UNKNOWN).to_owned()
+    clone_uppercased(VIOLET_NAME.unwrap_or(VIOLET_UNKNOWN))
 }

--- a/src/control/commands.rs
+++ b/src/control/commands.rs
@@ -6,7 +6,6 @@ use enum_dispatch::*;
 use std::process::exit;
 
 use crate::config::get_violet_name;
-use crate::util::string::clone_uppercased;
 
 #[enum_dispatch]
 #[derive(Clone)]
@@ -47,7 +46,7 @@ impl Action for WhatsYourNameCommand {
     fn execute(&self) {
         println!(
             "My name is {}! Nice to meet you ^_^",
-            clone_uppercased(&get_violet_name())
+            &get_violet_name()
         );
     }
 }


### PR DESCRIPTION
Unfortunately this small refactoring is the only reasonably possible change for now, more details in #24 itself.
After spending significant time on the originally planned refactoring, I realized that even though I had wanted to get rid of boilerplate/avoid spaghetti code in the future, it turned out the planned implementation method lead to even more boilerplate/spaghetti, and the benefit (the ability to choose where to print Violet's output) is not used anywhere for now, and I'm not sure it will ever be used. That's why for now I'm effectively cancelling this refactoring, and this pull request is just a small rearrangement of code effectively unrelated to the main issue.
