### PR TITLE
(#20) Implemented commands with a fixed number of arguments

### DIFF
--- a/src/control/commands.rs
+++ b/src/control/commands.rs
@@ -13,7 +13,7 @@ pub enum Command {
     ExitCommand,
     CurrentTimeCommand,
     WhatsYourNameCommand,
-    SayThisAndThatCommand
+    SayThisAndThatCommand,
 }
 
 #[enum_dispatch(Command)]
@@ -45,10 +45,7 @@ impl Action for CurrentTimeCommand {
 pub struct WhatsYourNameCommand;
 impl Action for WhatsYourNameCommand {
     fn execute(&self, _args: Vec<String>) {
-        println!(
-            "My name is {}! Nice to meet you ^_^",
-            &get_violet_name()
-        );
+        println!("My name is {}! Nice to meet you ^_^", &get_violet_name());
     }
 }
 
@@ -56,7 +53,14 @@ impl Action for WhatsYourNameCommand {
 pub struct SayThisAndThatCommand;
 impl Action for SayThisAndThatCommand {
     fn execute(&self, args: Vec<String>) {
-        if args.len() != 2 { println!("Something went horribly wrong..."); return; }
-        println!("Gotcha. Saying {} and {}!", args.get(0).unwrap(), args.get(1).unwrap());
+        if args.len() != 2 {
+            println!("Something went horribly wrong...");
+            return;
+        }
+        println!(
+            "Gotcha. Saying {} and {}!",
+            args.get(0).unwrap(),
+            args.get(1).unwrap()
+        );
     }
 }

--- a/src/control/commands.rs
+++ b/src/control/commands.rs
@@ -13,6 +13,7 @@ pub enum Command {
     ExitCommand,
     CurrentTimeCommand,
     WhatsYourNameCommand,
+    SayThisAndThatCommand
 }
 
 #[enum_dispatch(Command)]
@@ -48,5 +49,14 @@ impl Action for WhatsYourNameCommand {
             "My name is {}! Nice to meet you ^_^",
             &get_violet_name()
         );
+    }
+}
+
+#[derive(Clone)]
+pub struct SayThisAndThatCommand;
+impl Action for SayThisAndThatCommand {
+    fn execute(&self, args: Vec<String>) {
+        if args.len() != 2 { println!("Something went horribly wrong..."); return; }
+        println!("Gotcha. Saying {} and {}!", args.get(0).unwrap(), args.get(1).unwrap());
     }
 }

--- a/src/control/commands.rs
+++ b/src/control/commands.rs
@@ -17,13 +17,13 @@ pub enum Command {
 
 #[enum_dispatch(Command)]
 pub trait Action {
-    fn execute(&self);
+    fn execute(&self, args: Vec<String>);
 }
 
 #[derive(Clone)]
 pub struct ExitCommand;
 impl Action for ExitCommand {
-    fn execute(&self) {
+    fn execute(&self, _args: Vec<String>) {
         println!("BYE! AYAYA ^_^");
         exit(0);
     }
@@ -32,7 +32,7 @@ impl Action for ExitCommand {
 #[derive(Clone)]
 pub struct CurrentTimeCommand;
 impl Action for CurrentTimeCommand {
-    fn execute(&self) {
+    fn execute(&self, _args: Vec<String>) {
         println!(
             "Your system clock says it's {} now!",
             Local::now().format("%I:%M %p")
@@ -43,7 +43,7 @@ impl Action for CurrentTimeCommand {
 #[derive(Clone)]
 pub struct WhatsYourNameCommand;
 impl Action for WhatsYourNameCommand {
-    fn execute(&self) {
+    fn execute(&self, _args: Vec<String>) {
         println!(
             "My name is {}! Nice to meet you ^_^",
             &get_violet_name()

--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -23,6 +23,7 @@ impl Interpreter {
         builtins.set_by_path(Command::from(ExitCommand), "exit");
         builtins.set_by_path(Command::from(CurrentTimeCommand), "what time is it");
         builtins.set_by_path(Command::from(WhatsYourNameCommand), "what is your name");
+        builtins.set_by_path(Command::from(SayThisAndThatCommand), "please say <ARG> and <ARG>");
     }
 
     pub fn run_repl(&mut self) {
@@ -39,20 +40,17 @@ impl Interpreter {
 
         loop {
             let user_input = input::get_user_input(config::get_violet_prompt());
-            match user_input.as_str() {
-                "" => continue,
-                _ => match self.builtin_commands.get_by_path(user_input.as_str()) {
-                    None => {
-                        println!(
-                            "{}: command does not exist.",
-                            TreePath::prettify(user_input.as_str())
-                        );
-                        continue;
-                    }
-                    Some(cmd) => {
-                        cmd.value.execute(self.builtin_commands.get_args_vec_from_path(&user_input));
-                    }
+            match self.builtin_commands.get_command_and_args_from_path(&user_input) {
+                None => {
+                    println!(
+                        "{}: command does not exist.",
+                        TreePath::prettify(user_input.as_str())
+                    );
                 },
+                Some((path, args)) => {
+                    let cmd = self.builtin_commands.get_by_path(&path).unwrap();
+                    cmd.value.execute(args);
+                }
             }
         }
     }

--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -50,7 +50,7 @@ impl Interpreter {
                         continue;
                     }
                     Some(cmd) => {
-                        cmd.value.execute();
+                        cmd.value.execute(self.builtin_commands.get_args_vec_from_path(&user_input));
                     }
                 },
             }

--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -23,7 +23,10 @@ impl Interpreter {
         builtins.set_by_path(Command::from(ExitCommand), "exit");
         builtins.set_by_path(Command::from(CurrentTimeCommand), "what time is it");
         builtins.set_by_path(Command::from(WhatsYourNameCommand), "what is your name");
-        builtins.set_by_path(Command::from(SayThisAndThatCommand), "please say <ARG> and <ARG>");
+        builtins.set_by_path(
+            Command::from(SayThisAndThatCommand),
+            "please say <ARG> and <ARG>",
+        );
     }
 
     pub fn run_repl(&mut self) {
@@ -40,13 +43,16 @@ impl Interpreter {
 
         loop {
             let user_input = input::get_user_input(config::get_violet_prompt());
-            match self.builtin_commands.get_command_and_args_from_path(&user_input) {
+            match self
+                .builtin_commands
+                .get_command_and_args_from_path(&user_input)
+            {
                 None => {
                     println!(
                         "{}: command does not exist.",
                         TreePath::prettify(user_input.as_str())
                     );
-                },
+                }
                 Some((path, args)) => {
                     let cmd = self.builtin_commands.get_by_path(&path).unwrap();
                     cmd.value.execute(args);

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -64,6 +64,28 @@ where
             self.get_by_path(&path).is_some()
         }
     }
+
+
+    pub fn check_for_argumented_path(&self, path: &str) -> Option<String> {
+        let pathvec = TreePath::create_path(path);
+        let mut argumented: Vec<String> = vec![];
+        for path in TreePath::get_path_hierarchy(&pathvec.join(" ").to_owned()) {
+            let previous_state = argumented.clone();
+            argumented = TreePath::create_path(&TreePath::append_path_node(&argumented, TreePath::get_last_node(&path).unwrap().as_str()));
+            if PathTree::does_path_exist(self, &argumented.join(" ")) {
+                continue;
+            }
+            else {
+                let argified_from_previous = TreePath::append_path_node(&previous_state, "<ARG>");
+                if PathTree::does_path_exist(self, &argified_from_previous) {
+                    argumented = TreePath::create_path(&argified_from_previous);
+                }
+                else { return None; }
+            }
+        }
+
+        Some(path.to_owned())
+    }
 }
 
 #[test]
@@ -209,4 +231,24 @@ fn test_pathing_works_with_untrimmed_paths() {
         true,
         test_tree.tree.contains_key("something completely bonkers")
     );
+}
+
+#[test]
+fn check_argumented_paths() {
+    let mut test_tree = PathTree::new();
+    test_tree.set_by_path("garbage", "this is <ARG> another <ARG>");
+    test_tree.set_by_path("garbage", "oh my god its <ARG> working <ARG> !!!");
+    test_tree.set_by_path("garbage", "<ARG> I cant believe <ARG>");
+
+    assert_eq!(Some(String::from("this is just another test")), test_tree.check_for_argumented_path("this is just another test"));
+    assert_eq!(Some(String::from("this is pooka another kooka")), test_tree.check_for_argumented_path("this is pooka another kooka"));
+    assert_eq!(Some(String::from("this is $$ another ---")), test_tree.check_for_argumented_path("this is $$ another ---"));
+    assert_eq!(None, test_tree.check_for_argumented_path("this is not just another test"));
+    assert_eq!(Some(String::from("oh my god its actually working OMG !!!")), test_tree.check_for_argumented_path("oh my god its actually working OMG !!!"));
+    assert_eq!(Some(String::from("oh my god its kekek working lulul !!!")), test_tree.check_for_argumented_path("oh my god its kekek working lulul !!!"));
+    assert_eq!(None, test_tree.check_for_argumented_path("oh my god its not actually working lulul ? !!!"));
+    assert_eq!(Some(String::from("Jesus I cant believe it!!!")), test_tree.check_for_argumented_path("Jesus I cant believe it!!!"));
+    assert_eq!(Some(String::from("123 I cant believe 584")), test_tree.check_for_argumented_path("123 I cant believe 584"));
+    assert_eq!(Some(String::from("<ARG> I cant believe <ARG>")), test_tree.check_for_argumented_path("<ARG> I cant believe <ARG>"));
+    assert_eq!(None, test_tree.check_for_argumented_path("OMG I can believe this"));
 }

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -65,24 +65,26 @@ where
         }
     }
 
-
     pub fn get_command_and_args_from_path(&self, path: &str) -> Option<(String, Vec<String>)> {
         let pathvec = TreePath::create_path(path);
         let mut args: Vec<String> = vec![];
         let mut argumented: Vec<String> = vec![];
-        for path in TreePath::get_path_hierarchy(&pathvec.join(" ").to_owned()) {
+        for path in TreePath::get_path_hierarchy(&pathvec.join(" ")) {
             let previous_state = argumented.clone();
-            argumented = TreePath::create_path(&TreePath::append_path_node(&argumented, TreePath::get_last_node(&path).unwrap().as_str()));
+            argumented = TreePath::create_path(&TreePath::append_path_node(
+                &argumented,
+                TreePath::get_last_node(&path).unwrap().as_str(),
+            ));
             if PathTree::does_path_exist(self, &argumented.join(" ")) {
                 continue;
-            }
-            else {
+            } else {
                 let argified_from_previous = TreePath::append_path_node(&previous_state, "<ARG>");
                 if PathTree::does_path_exist(self, &argified_from_previous) {
                     argumented = TreePath::create_path(&argified_from_previous);
                     args.push(TreePath::get_last_node(&path).unwrap());
+                } else {
+                    return None;
                 }
-                else { return None }
             }
         }
 
@@ -241,20 +243,87 @@ fn check_argumented_paths() {
     test_tree.set_by_path("garbage", "this is <ARG> another <ARG>");
     test_tree.set_by_path("garbage", "oh my god its <ARG> working <ARG> !!!");
     test_tree.set_by_path("garbage", "<ARG> I cant believe <ARG>");
-    test_tree.set_by_path("garbage", "<ARG> and <ARG> and <ARG> and <ARG> and <ARG> and KEKW");
+    test_tree.set_by_path(
+        "garbage",
+        "<ARG> and <ARG> and <ARG> and <ARG> and <ARG> and KEKW",
+    );
 
-    assert_eq!(Some((String::from("this is <ARG> another <ARG>"), vec![String::from("just"), String::from("test")])), test_tree.get_command_and_args_from_path("this is just another test"));
-    assert_eq!(Some((String::from("this is <ARG> another <ARG>"), vec![String::from("pooka"), String::from("kooka")])), test_tree.get_command_and_args_from_path("this is pooka another kooka"));
-    assert_eq!(Some((String::from("this is <ARG> another <ARG>"), vec![String::from("$$"), String::from("---")])), test_tree.get_command_and_args_from_path("this is $$ another ---"));
-    assert_eq!(None, test_tree.get_command_and_args_from_path("this is not just another test"));
+    assert_eq!(
+        Some((
+            String::from("this is <ARG> another <ARG>"),
+            vec![String::from("just"), String::from("test")]
+        )),
+        test_tree.get_command_and_args_from_path("this is just another test")
+    );
+    assert_eq!(
+        Some((
+            String::from("this is <ARG> another <ARG>"),
+            vec![String::from("pooka"), String::from("kooka")]
+        )),
+        test_tree.get_command_and_args_from_path("this is pooka another kooka")
+    );
+    assert_eq!(
+        Some((
+            String::from("this is <ARG> another <ARG>"),
+            vec![String::from("$$"), String::from("---")]
+        )),
+        test_tree.get_command_and_args_from_path("this is $$ another ---")
+    );
+    assert_eq!(
+        None,
+        test_tree.get_command_and_args_from_path("this is not just another test")
+    );
 
-    assert_eq!(Some((String::from("oh my god its <ARG> working <ARG> !!!"), vec![String::from("actually"), String::from("OMG")])), test_tree.get_command_and_args_from_path("oh my god its actually working OMG !!!"));
-    assert_eq!(Some((String::from("oh my god its <ARG> working <ARG> !!!"), vec![String::from("kekek"), String::from("lulul")])), test_tree.get_command_and_args_from_path("oh my god its kekek working lulul !!!"));
-    assert_eq!(None, test_tree.get_command_and_args_from_path("oh my god its not actually working lulul ? !!!"));
+    assert_eq!(
+        Some((
+            String::from("oh my god its <ARG> working <ARG> !!!"),
+            vec![String::from("actually"), String::from("OMG")]
+        )),
+        test_tree.get_command_and_args_from_path("oh my god its actually working OMG !!!")
+    );
+    assert_eq!(
+        Some((
+            String::from("oh my god its <ARG> working <ARG> !!!"),
+            vec![String::from("kekek"), String::from("lulul")]
+        )),
+        test_tree.get_command_and_args_from_path("oh my god its kekek working lulul !!!")
+    );
+    assert_eq!(
+        None,
+        test_tree.get_command_and_args_from_path("oh my god its not actually working lulul ? !!!")
+    );
 
-    assert_eq!(Some((String::from("<ARG> I cant believe <ARG>"), vec![String::from("Jesus"), String::from("it!!!")])), test_tree.get_command_and_args_from_path("Jesus I cant believe it!!!"));
-    assert_eq!(Some((String::from("<ARG> I cant believe <ARG>"), vec![String::from("123"), String::from("584")])), test_tree.get_command_and_args_from_path("123 I cant believe 584"));
-    assert_eq!(None, test_tree.get_command_and_args_from_path("OMG I can believe this"));
+    assert_eq!(
+        Some((
+            String::from("<ARG> I cant believe <ARG>"),
+            vec![String::from("Jesus"), String::from("it!!!")]
+        )),
+        test_tree.get_command_and_args_from_path("Jesus I cant believe it!!!")
+    );
+    assert_eq!(
+        Some((
+            String::from("<ARG> I cant believe <ARG>"),
+            vec![String::from("123"), String::from("584")]
+        )),
+        test_tree.get_command_and_args_from_path("123 I cant believe 584")
+    );
+    assert_eq!(
+        None,
+        test_tree.get_command_and_args_from_path("OMG I can believe this")
+    );
 
-    assert_eq!(Some((String::from("<ARG> and <ARG> and <ARG> and <ARG> and <ARG> and KEKW"), vec![String::from("one"), String::from("two"), String::from("three"), String::from("four"), String::from("five")])), test_tree.get_command_and_args_from_path("one and two and three and four and five and KEKW"));
+    assert_eq!(
+        Some((
+            String::from("<ARG> and <ARG> and <ARG> and <ARG> and <ARG> and KEKW"),
+            vec![
+                String::from("one"),
+                String::from("two"),
+                String::from("three"),
+                String::from("four"),
+                String::from("five")
+            ]
+        )),
+        test_tree
+            .get_command_and_args_from_path("one and two and three and four and five and KEKW")
+    );
 }

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -66,8 +66,9 @@ where
     }
 
 
-    pub fn check_for_argumented_path(&self, path: &str) -> Option<String> {
+    pub fn get_args_vec_from_path(&self, path: &str) -> Vec<String> {
         let pathvec = TreePath::create_path(path);
+        let mut args: Vec<String> = vec![];
         let mut argumented: Vec<String> = vec![];
         for path in TreePath::get_path_hierarchy(&pathvec.join(" ").to_owned()) {
             let previous_state = argumented.clone();
@@ -79,12 +80,13 @@ where
                 let argified_from_previous = TreePath::append_path_node(&previous_state, "<ARG>");
                 if PathTree::does_path_exist(self, &argified_from_previous) {
                     argumented = TreePath::create_path(&argified_from_previous);
+                    args.push(TreePath::get_last_node(&path).unwrap());
                 }
-                else { return None; }
+                else { return vec![] }
             }
         }
 
-        Some(path.to_owned())
+        args
     }
 }
 
@@ -239,16 +241,17 @@ fn check_argumented_paths() {
     test_tree.set_by_path("garbage", "this is <ARG> another <ARG>");
     test_tree.set_by_path("garbage", "oh my god its <ARG> working <ARG> !!!");
     test_tree.set_by_path("garbage", "<ARG> I cant believe <ARG>");
+    test_tree.set_by_path("garbage", "<ARG> and <ARG> and <ARG> and <ARG> and <ARG> and KEKW");
 
-    assert_eq!(Some(String::from("this is just another test")), test_tree.check_for_argumented_path("this is just another test"));
-    assert_eq!(Some(String::from("this is pooka another kooka")), test_tree.check_for_argumented_path("this is pooka another kooka"));
-    assert_eq!(Some(String::from("this is $$ another ---")), test_tree.check_for_argumented_path("this is $$ another ---"));
-    assert_eq!(None, test_tree.check_for_argumented_path("this is not just another test"));
-    assert_eq!(Some(String::from("oh my god its actually working OMG !!!")), test_tree.check_for_argumented_path("oh my god its actually working OMG !!!"));
-    assert_eq!(Some(String::from("oh my god its kekek working lulul !!!")), test_tree.check_for_argumented_path("oh my god its kekek working lulul !!!"));
-    assert_eq!(None, test_tree.check_for_argumented_path("oh my god its not actually working lulul ? !!!"));
-    assert_eq!(Some(String::from("Jesus I cant believe it!!!")), test_tree.check_for_argumented_path("Jesus I cant believe it!!!"));
-    assert_eq!(Some(String::from("123 I cant believe 584")), test_tree.check_for_argumented_path("123 I cant believe 584"));
-    assert_eq!(Some(String::from("<ARG> I cant believe <ARG>")), test_tree.check_for_argumented_path("<ARG> I cant believe <ARG>"));
-    assert_eq!(None, test_tree.check_for_argumented_path("OMG I can believe this"));
+    assert_eq!(vec!["just", "test"], test_tree.get_args_vec_from_path("this is just another test"));
+    assert_eq!(vec!["pooka", "kooka"], test_tree.get_args_vec_from_path("this is pooka another kooka"));
+    assert_eq!(vec!["$$", "---"], test_tree.get_args_vec_from_path("this is $$ another ---"));
+    assert_eq!(Vec::<String>::new(), test_tree.get_args_vec_from_path("this is not just another test"));
+    assert_eq!(vec!["actually", "OMG"], test_tree.get_args_vec_from_path("oh my god its actually working OMG !!!"));
+    assert_eq!(vec!["kekek", "lulul"], test_tree.get_args_vec_from_path("oh my god its kekek working lulul !!!"));
+    assert_eq!(Vec::<String>::new(), test_tree.get_args_vec_from_path("oh my god its not actually working lulul ? !!!"));
+    assert_eq!(vec!["Jesus", "it!!!"], test_tree.get_args_vec_from_path("Jesus I cant believe it!!!"));
+    assert_eq!(vec!["123", "584"], test_tree.get_args_vec_from_path("123 I cant believe 584"));
+    assert_eq!(Vec::<String>::new(), test_tree.get_args_vec_from_path("OMG I can believe this"));
+    assert_eq!(vec!["one", "two", "three", "four", "five"], test_tree.get_args_vec_from_path("one and two and three and four and five and KEKW"));
 }

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -66,7 +66,7 @@ where
     }
 
 
-    pub fn get_args_vec_from_path(&self, path: &str) -> Vec<String> {
+    pub fn get_command_and_args_from_path(&self, path: &str) -> Option<(String, Vec<String>)> {
         let pathvec = TreePath::create_path(path);
         let mut args: Vec<String> = vec![];
         let mut argumented: Vec<String> = vec![];
@@ -82,11 +82,11 @@ where
                     argumented = TreePath::create_path(&argified_from_previous);
                     args.push(TreePath::get_last_node(&path).unwrap());
                 }
-                else { return vec![] }
+                else { return None }
             }
         }
 
-        args
+        Some((argumented.join(" "), args))
     }
 }
 
@@ -243,15 +243,18 @@ fn check_argumented_paths() {
     test_tree.set_by_path("garbage", "<ARG> I cant believe <ARG>");
     test_tree.set_by_path("garbage", "<ARG> and <ARG> and <ARG> and <ARG> and <ARG> and KEKW");
 
-    assert_eq!(vec!["just", "test"], test_tree.get_args_vec_from_path("this is just another test"));
-    assert_eq!(vec!["pooka", "kooka"], test_tree.get_args_vec_from_path("this is pooka another kooka"));
-    assert_eq!(vec!["$$", "---"], test_tree.get_args_vec_from_path("this is $$ another ---"));
-    assert_eq!(Vec::<String>::new(), test_tree.get_args_vec_from_path("this is not just another test"));
-    assert_eq!(vec!["actually", "OMG"], test_tree.get_args_vec_from_path("oh my god its actually working OMG !!!"));
-    assert_eq!(vec!["kekek", "lulul"], test_tree.get_args_vec_from_path("oh my god its kekek working lulul !!!"));
-    assert_eq!(Vec::<String>::new(), test_tree.get_args_vec_from_path("oh my god its not actually working lulul ? !!!"));
-    assert_eq!(vec!["Jesus", "it!!!"], test_tree.get_args_vec_from_path("Jesus I cant believe it!!!"));
-    assert_eq!(vec!["123", "584"], test_tree.get_args_vec_from_path("123 I cant believe 584"));
-    assert_eq!(Vec::<String>::new(), test_tree.get_args_vec_from_path("OMG I can believe this"));
-    assert_eq!(vec!["one", "two", "three", "four", "five"], test_tree.get_args_vec_from_path("one and two and three and four and five and KEKW"));
+    assert_eq!(Some((String::from("this is <ARG> another <ARG>"), vec![String::from("just"), String::from("test")])), test_tree.get_command_and_args_from_path("this is just another test"));
+    assert_eq!(Some((String::from("this is <ARG> another <ARG>"), vec![String::from("pooka"), String::from("kooka")])), test_tree.get_command_and_args_from_path("this is pooka another kooka"));
+    assert_eq!(Some((String::from("this is <ARG> another <ARG>"), vec![String::from("$$"), String::from("---")])), test_tree.get_command_and_args_from_path("this is $$ another ---"));
+    assert_eq!(None, test_tree.get_command_and_args_from_path("this is not just another test"));
+
+    assert_eq!(Some((String::from("oh my god its <ARG> working <ARG> !!!"), vec![String::from("actually"), String::from("OMG")])), test_tree.get_command_and_args_from_path("oh my god its actually working OMG !!!"));
+    assert_eq!(Some((String::from("oh my god its <ARG> working <ARG> !!!"), vec![String::from("kekek"), String::from("lulul")])), test_tree.get_command_and_args_from_path("oh my god its kekek working lulul !!!"));
+    assert_eq!(None, test_tree.get_command_and_args_from_path("oh my god its not actually working lulul ? !!!"));
+
+    assert_eq!(Some((String::from("<ARG> I cant believe <ARG>"), vec![String::from("Jesus"), String::from("it!!!")])), test_tree.get_command_and_args_from_path("Jesus I cant believe it!!!"));
+    assert_eq!(Some((String::from("<ARG> I cant believe <ARG>"), vec![String::from("123"), String::from("584")])), test_tree.get_command_and_args_from_path("123 I cant believe 584"));
+    assert_eq!(None, test_tree.get_command_and_args_from_path("OMG I can believe this"));
+
+    assert_eq!(Some((String::from("<ARG> and <ARG> and <ARG> and <ARG> and <ARG> and KEKW"), vec![String::from("one"), String::from("two"), String::from("three"), String::from("four"), String::from("five")])), test_tree.get_command_and_args_from_path("one and two and three and four and five and KEKW"));
 }

--- a/src/util/treepath.rs
+++ b/src/util/treepath.rs
@@ -26,4 +26,18 @@ impl TreePath {
     pub fn prettify(path: &str) -> String {
         TreePath::create_path(path).join(" ")
     }
+
+    pub fn append_path_node(path: &Vec<String>, node_to_append: &str) -> String {
+        let mut newpathvec = path.to_owned();
+        newpathvec.push(node_to_append.to_owned());
+        newpathvec.join(" ")
+    }
+
+    pub fn get_last_node(of_path: &str) -> Option<String> {
+        let path = TreePath::create_path(of_path);
+        match path.last() {
+            Some(node) => Some(node.to_owned()),
+            None => None
+        }
+    }
 }

--- a/src/util/treepath.rs
+++ b/src/util/treepath.rs
@@ -27,7 +27,7 @@ impl TreePath {
         TreePath::create_path(path).join(" ")
     }
 
-    pub fn append_path_node(path: &Vec<String>, node_to_append: &str) -> String {
+    pub fn append_path_node(path: &[String], node_to_append: &str) -> String {
         let mut newpathvec = path.to_owned();
         newpathvec.push(node_to_append.to_owned());
         newpathvec.join(" ")
@@ -37,7 +37,7 @@ impl TreePath {
         let path = TreePath::create_path(of_path);
         match path.last() {
             Some(node) => Some(node.to_owned()),
-            None => None
+            None => None,
         }
     }
 }


### PR DESCRIPTION
- Added the mechanism for checking if a command is argumented or not, and if yes, collecting the arguments from the user-specified command line;
- Integrated the mechanism into the interpreter;
- Created a new command called `SayThisAndThatCommand` that is called via `please say <ARG> and <ARG>` and it literally says those two things marked as <ARG>. This is to test that the commands with arguments work;
- Unit tested the thing.