### PR TITLE
[#21] Implemented multiword arguments in Violet

### DIFF
--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -73,15 +73,15 @@ where
 
         let mut loop_validation = true;
         nodes.iter().enumerate().for_each(|(index, node)| {
-            if node.starts_with("\"") && node.len() == 1 {
+            if node.starts_with('\"') && node.len() == 1 {
                 loop_validation = false;
                 return;
             }
 
-            if node.starts_with("\"") {
+            if node.starts_with('\"') {
                 slice_indices.0.push(index as u32);
             }
-            if node.ends_with("\"") {
+            if node.ends_with('\"') {
                 slice_indices.1.push(index as u32);
             }
         });
@@ -98,14 +98,18 @@ where
 
         let mut previous_end_index: u32 = 0;
         let mut loop_validation = true;
-        slice_indices.0.iter().enumerate().for_each(|(index, start)| {
-            let end = slice_indices.1.get(index).unwrap();
-            if *start > *end || *start < previous_end_index {
-                loop_validation = false;
-            }
+        slice_indices
+            .0
+            .iter()
+            .enumerate()
+            .for_each(|(index, start)| {
+                let end = slice_indices.1.get(index).unwrap();
+                if *start > *end || *start < previous_end_index {
+                    loop_validation = false;
+                }
 
-            previous_end_index = *end;
-        });
+                previous_end_index = *end;
+            });
         if !loop_validation {
             return None;
         }
@@ -113,36 +117,35 @@ where
         for arg_number in 0..slice_indices.0.len() {
             let lower_index = slice_indices.0[arg_number] as usize;
             let upper_index = slice_indices.1[arg_number] as usize;
-            
+
             let mut new_arg: Vec<String> = vec![];
             new_arg.extend_from_slice(&nodes[lower_index..=upper_index]);
             let mut new_arg = new_arg.join(" ");
-            new_arg.remove(0); new_arg.remove(new_arg.len() - 1);
+            new_arg.remove(0);
+            new_arg.remove(new_arg.len() - 1);
             args.push(new_arg);
         }
 
         let mut started: bool = false;
-        for nodes_index in 0..nodes.len() {
-            if nodes[nodes_index].starts_with("\"") {
+        for node in &nodes {
+            if node.starts_with('\"') {
                 started = true;
                 resulting_pathvec.push("<ARG>".to_owned());
             }
 
-            if !nodes[nodes_index].starts_with("\"") && !nodes[nodes_index].ends_with("\"") && !started
-            {
-                resulting_pathvec.push(nodes[nodes_index].clone());
+            if !node.starts_with('\"') && !node.ends_with('\"') && !started {
+                resulting_pathvec.push(node.clone());
             }
 
-            if nodes[nodes_index].ends_with("\"") {
+            if node.ends_with('\"') {
                 started = false;
             }
         }
 
         let resulting_path = resulting_pathvec.join(" ");
-        if self.does_node_exist(resulting_path.clone().as_str()) {
+        if self.does_node_exist(resulting_path.as_str()) {
             Some((resulting_path, args))
-        }
-        else {
+        } else {
             None
         }
     }
@@ -177,8 +180,7 @@ where
     pub fn get_command_and_args_from_path(&self, path: &str) -> Option<(String, Vec<String>)> {
         if let Some((mw_command, mw_args)) = self.attempt_multiword_parsing(path) {
             Some((mw_command, mw_args))
-        }
-        else {
+        } else {
             self.attempt_single_word_parsing(path)
         }
     }

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -57,6 +57,14 @@ where
         self.tree.contains_key(&TreePath::prettify(path))
     }
 
+    pub fn does_node_exist(&self, path: &str) -> bool {
+        if !self.does_path_exist(&path) {
+            false
+        } else {
+            self.get_by_path(&path).is_some()
+        }
+    }
+
     fn attempt_multiword_parsing(&self, path: &str) -> Option<(String, Vec<String>)> {
         let nodes = TreePath::create_path(path);
         let mut slice_indices: (Vec<u32>, Vec<u32>) = (vec![], vec![]);
@@ -93,15 +101,11 @@ where
             return None;
         }
 
-        for arg_number in 0..=slice_indices.0.len() - 1 {
+        for arg_number in 0..slice_indices.0.len() - 1 {
             let lower_index = slice_indices.0[arg_number] as usize;
             let upper_index = slice_indices.1[arg_number] as usize;
-
-            let mut new_arg: Vec<String> = vec![];
-            new_arg.extend_from_slice(&nodes[lower_index..=upper_index]);
-            let mut new_arg = new_arg.join(" ");
-            new_arg.remove(0); new_arg.remove(new_arg.len() - 1);
-            args.push(new_arg);
+            let new_arg = &nodes[lower_index..=upper_index];
+            args.push(new_arg.join(" "));
         }
 
         let mut started: bool = false;
@@ -195,16 +199,31 @@ fn test_tree_setters_and_getters() {
         "test garbage val".to_string(),
         "そっか おふの $%?рашин /fourth .fifth \\sixth",
     );
+    assert_eq!(false, test_tree.does_node_exist("そっか"));
     assert_eq!(true, test_tree.does_path_exist("そっか"));
+    assert_eq!(false, test_tree.does_node_exist("そっか おふの"));
     assert_eq!(true, test_tree.does_path_exist("そっか おふの"));
+    assert_eq!(false, test_tree.does_node_exist("そっか おふの $%?рашин"));
     assert_eq!(true, test_tree.does_path_exist("そっか おふの $%?рашин"));
+    assert_eq!(
+        false,
+        test_tree.does_node_exist("そっか おふの $%?рашин /fourth")
+    );
     assert_eq!(
         true,
         test_tree.does_path_exist("そっか おふの $%?рашин /fourth")
     );
     assert_eq!(
+        false,
+        test_tree.does_node_exist("そっか おふの $%?рашин /fourth .fifth")
+    );
+    assert_eq!(
         true,
         test_tree.does_path_exist("そっか おふの $%?рашин /fourth .fifth")
+    );
+    assert_eq!(
+        true,
+        test_tree.does_node_exist("そっか おふの $%?рашин /fourth .fifth \\sixth")
     );
     assert_eq!(
         true,
@@ -243,6 +262,7 @@ fn check_empty_path_creation() {
     );
     assert_eq!(Vec::<String>::new(), TreePath::get_path_hierarchy(""));
 
+    assert_eq!(false, test_tree.does_node_exist(""));
     assert_eq!(None, test_tree.get_by_path(""));
 }
 
@@ -260,8 +280,14 @@ fn test_pathing_works_with_untrimmed_paths() {
 
     test_tree.set_by_path("test garbage val".to_string(), path);
 
+    assert_eq!(false, test_tree.does_node_exist("something"));
     assert_eq!(true, test_tree.does_path_exist("something"));
+    assert_eq!(false, test_tree.does_node_exist("something completely"));
     assert_eq!(true, test_tree.does_path_exist("something completely"));
+    assert_eq!(
+        true,
+        test_tree.does_node_exist("something completely bonkers")
+    );
     assert_eq!(
         true,
         test_tree.does_path_exist("something completely bonkers")

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -129,7 +129,13 @@ where
             }
         }
 
-        Some((resulting_pathvec.join(" "), args))
+        let resulting_path = resulting_pathvec.join(" ");
+        if self.does_node_exist(resulting_path.clone().as_str()) {
+            Some((resulting_path, args))
+        }
+        else {
+            None
+        }
     }
 
     fn attempt_single_word_parsing(&self, path: &str) -> Option<(String, Vec<String>)> {

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -110,7 +110,7 @@ where
             return None;
         }
 
-        for arg_number in 0..=slice_indices.0.len() - 1 {
+        for arg_number in 0..slice_indices.0.len() {
             let lower_index = slice_indices.0[arg_number] as usize;
             let upper_index = slice_indices.1[arg_number] as usize;
             
@@ -122,7 +122,7 @@ where
         }
 
         let mut started: bool = false;
-        for nodes_index in 0..nodes.len() - 1 {
+        for nodes_index in 0..nodes.len() {
             if nodes[nodes_index].starts_with("\"") {
                 started = true;
                 resulting_pathvec.push("<ARG>".to_owned());

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -65,7 +65,11 @@ where
         }
     }
 
-    pub fn get_command_and_args_from_path(&self, path: &str) -> Option<(String, Vec<String>)> {
+    fn attempt_multiword_parsing(&self, path: &str) -> Option<(String, Vec<String>)> {
+        None
+    }
+
+    fn attempt_single_word_parsing(&self, path: &str) -> Option<(String, Vec<String>)> {
         let pathvec = TreePath::create_path(path);
         let mut args: Vec<String> = vec![];
         let mut argumented: Vec<String> = vec![];
@@ -75,11 +79,11 @@ where
                 &argumented,
                 TreePath::get_last_node(&path).unwrap().as_str(),
             ));
-            if PathTree::does_path_exist(self, &argumented.join(" ")) {
+            if self.does_path_exist(&argumented.join(" ")) {
                 continue;
             } else {
                 let argified_from_previous = TreePath::append_path_node(&previous_state, "<ARG>");
-                if PathTree::does_path_exist(self, &argified_from_previous) {
+                if self.does_path_exist(&argified_from_previous) {
                     argumented = TreePath::create_path(&argified_from_previous);
                     args.push(TreePath::get_last_node(&path).unwrap());
                 } else {
@@ -89,6 +93,15 @@ where
         }
 
         Some((argumented.join(" "), args))
+    }
+
+    pub fn get_command_and_args_from_path(&self, path: &str) -> Option<(String, Vec<String>)> {
+        if let Some((mw_command, mw_args)) = self.attempt_multiword_parsing(path) {
+            Some((mw_command, mw_args))
+        }
+        else {
+            self.attempt_single_word_parsing(path)
+        }
     }
 }
 

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -101,11 +101,15 @@ where
             return None;
         }
 
-        for arg_number in 0..slice_indices.0.len() - 1 {
+        for arg_number in 0..=slice_indices.0.len() - 1 {
             let lower_index = slice_indices.0[arg_number] as usize;
             let upper_index = slice_indices.1[arg_number] as usize;
-            let new_arg = &nodes[lower_index..=upper_index];
-            args.push(new_arg.join(" "));
+            
+            let mut new_arg: Vec<String> = vec![];
+            new_arg.extend_from_slice(&nodes[lower_index..=upper_index]);
+            let mut new_arg = new_arg.join(" ");
+            new_arg.remove(0); new_arg.remove(new_arg.len() - 1);
+            args.push(new_arg);
         }
 
         let mut started: bool = false;

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -57,14 +57,6 @@ where
         self.tree.contains_key(&TreePath::prettify(path))
     }
 
-    pub fn does_node_exist(&self, path: &str) -> bool {
-        if !self.does_path_exist(&path) {
-            false
-        } else {
-            self.get_by_path(&path).is_some()
-        }
-    }
-
     fn attempt_multiword_parsing(&self, path: &str) -> Option<(String, Vec<String>)> {
         let nodes = TreePath::create_path(path);
         let mut slice_indices: (Vec<u32>, Vec<u32>) = (vec![], vec![]);
@@ -101,11 +93,15 @@ where
             return None;
         }
 
-        for arg_number in 0..slice_indices.0.len() - 1 {
+        for arg_number in 0..=slice_indices.0.len() - 1 {
             let lower_index = slice_indices.0[arg_number] as usize;
             let upper_index = slice_indices.1[arg_number] as usize;
-            let new_arg = &nodes[lower_index..=upper_index];
-            args.push(new_arg.join(" "));
+
+            let mut new_arg: Vec<String> = vec![];
+            new_arg.extend_from_slice(&nodes[lower_index..=upper_index]);
+            let mut new_arg = new_arg.join(" ");
+            new_arg.remove(0); new_arg.remove(new_arg.len() - 1);
+            args.push(new_arg);
         }
 
         let mut started: bool = false;
@@ -199,31 +195,16 @@ fn test_tree_setters_and_getters() {
         "test garbage val".to_string(),
         "そっか おふの $%?рашин /fourth .fifth \\sixth",
     );
-    assert_eq!(false, test_tree.does_node_exist("そっか"));
     assert_eq!(true, test_tree.does_path_exist("そっか"));
-    assert_eq!(false, test_tree.does_node_exist("そっか おふの"));
     assert_eq!(true, test_tree.does_path_exist("そっか おふの"));
-    assert_eq!(false, test_tree.does_node_exist("そっか おふの $%?рашин"));
     assert_eq!(true, test_tree.does_path_exist("そっか おふの $%?рашин"));
-    assert_eq!(
-        false,
-        test_tree.does_node_exist("そっか おふの $%?рашин /fourth")
-    );
     assert_eq!(
         true,
         test_tree.does_path_exist("そっか おふの $%?рашин /fourth")
     );
     assert_eq!(
-        false,
-        test_tree.does_node_exist("そっか おふの $%?рашин /fourth .fifth")
-    );
-    assert_eq!(
         true,
         test_tree.does_path_exist("そっか おふの $%?рашин /fourth .fifth")
-    );
-    assert_eq!(
-        true,
-        test_tree.does_node_exist("そっか おふの $%?рашин /fourth .fifth \\sixth")
     );
     assert_eq!(
         true,
@@ -262,7 +243,6 @@ fn check_empty_path_creation() {
     );
     assert_eq!(Vec::<String>::new(), TreePath::get_path_hierarchy(""));
 
-    assert_eq!(false, test_tree.does_node_exist(""));
     assert_eq!(None, test_tree.get_by_path(""));
 }
 
@@ -280,14 +260,8 @@ fn test_pathing_works_with_untrimmed_paths() {
 
     test_tree.set_by_path("test garbage val".to_string(), path);
 
-    assert_eq!(false, test_tree.does_node_exist("something"));
     assert_eq!(true, test_tree.does_path_exist("something"));
-    assert_eq!(false, test_tree.does_node_exist("something completely"));
     assert_eq!(true, test_tree.does_path_exist("something completely"));
-    assert_eq!(
-        true,
-        test_tree.does_node_exist("something completely bonkers")
-    );
     assert_eq!(
         true,
         test_tree.does_path_exist("something completely bonkers")

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -71,7 +71,13 @@ where
         let mut args: Vec<String> = vec![];
         let mut resulting_pathvec: Vec<String> = vec![];
 
+        let mut loop_validation = true;
         nodes.iter().enumerate().for_each(|(index, node)| {
+            if node.starts_with("\"") && node.len() == 1 {
+                loop_validation = false;
+                return;
+            }
+
             if node.starts_with("\"") {
                 slice_indices.0.push(index as u32);
             }
@@ -79,6 +85,9 @@ where
                 slice_indices.1.push(index as u32);
             }
         });
+        if !loop_validation {
+            return None;
+        }
 
         if slice_indices.0.is_empty() || slice_indices.1.is_empty() {
             return None;

--- a/src/util/treepath.rs
+++ b/src/util/treepath.rs
@@ -16,7 +16,7 @@ impl TreePath {
 
         path.iter().for_each(|path_node| {
             current_path.push_str(path_node.clone().as_str());
-            current_path.push_str(" ");
+            current_path.push(' ');
             hierarchy.push(current_path.trim().to_string());
         });
 


### PR DESCRIPTION
If we have a command like `please say <ARG> and <ARG>`, and we use double quotes `"` for multi word arguments, like so: `please say "first argument" and "second argument"`, both multiword arguments will get recognized and printed out.

Spaces before the initial and the final quote (`please say "  first arg  " and "  second arg  "`) are considered illegal and will cause Violet to not find the command.

Multiple spaces within a multiword argument (`please say "this<space><space><space>word" and "that<space><space>word"`) will get truncated into a single space: "Saying this word and that word!".

Marking spaces in the last example as <space> because of markdown's issues with multiple spaces in a row.