### PR TITLE
[#4] Implemented aliases for builtin commands.

### DIFF
--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -34,11 +34,17 @@ impl Interpreter {
     }
 
     fn set_all_aliases(aliases: &mut PathTree<String>) {
-        aliases.set_by_path(String::from("please say <ARG> and <ARG>"), "utter <ARG> and <ARG> ye heretic");
+        aliases.set_by_path(
+            String::from("please say <ARG> and <ARG>"),
+            "utter <ARG> and <ARG> ye heretic",
+        );
         aliases.set_by_path(String::from("exit"), "get the heck outta here");
         aliases.set_by_path(String::from("what time is it"), "are we there yet");
         aliases.set_by_path(String::from("what is your name"), "what even are you");
-        aliases.set_by_path(String::from("please say <ARG> and <ARG>"), "blabber <ARG> and <ARG>");
+        aliases.set_by_path(
+            String::from("please say <ARG> and <ARG>"),
+            "blabber <ARG> and <ARG>",
+        );
     }
 
     pub fn run_repl(&mut self) {
@@ -56,17 +62,27 @@ impl Interpreter {
         loop {
             let user_input = input::get_user_input(config::get_violet_prompt());
             let command_to_invoke: String = match self
-                    .aliases_for_builtins
-                    .get_command_and_args_from_path(&user_input) {
+                .aliases_for_builtins
+                .get_command_and_args_from_path(&user_input)
+            {
                 None => user_input,
                 Some((path, args)) => {
                     if self.aliases_for_builtins.does_node_exist(&path) {
-                        TreePath::reconstruct_argumented_path(self.aliases_for_builtins.get_by_path(&path).unwrap().value.clone(), args).unwrap_or(String::from("ERROR: alias and builtin argument counts are different!"))
-                    }
-                    else {
+                        TreePath::reconstruct_argumented_path(
+                            self.aliases_for_builtins
+                                .get_by_path(&path)
+                                .unwrap()
+                                .value
+                                .clone(),
+                            args,
+                        )
+                        .unwrap_or_else(|| String::from(
+                            "ERROR: alias and builtin argument counts are different!",
+                        ))
+                    } else {
                         user_input
                     }
-                },
+                }
             };
 
             match self
@@ -83,8 +99,7 @@ impl Interpreter {
                     if self.builtin_commands.does_node_exist(&path) {
                         let cmd = self.builtin_commands.get_by_path(&path).unwrap();
                         cmd.value.execute(args);
-                    }
-                    else {
+                    } else {
                         println!(
                             "{}: command does not exist.",
                             TreePath::prettify(command_to_invoke.as_str())

--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -59,7 +59,7 @@ impl Interpreter {
                     .aliases_for_builtins
                     .get_command_and_args_from_path(&user_input) {
                 None => user_input,
-                Some((path, args)) => TreePath::reconstruct_argumented_path(self.aliases_for_builtins.get_by_path(&path).unwrap().value.clone(), args).unwrap_or(String::from("ERROR")),
+                Some((path, args)) => TreePath::reconstruct_argumented_path(self.aliases_for_builtins.get_by_path(&path).unwrap().value.clone(), args).unwrap_or(String::from("ERROR: alias and builtin argument counts are different!")),
             };
             match self
                 .builtin_commands

--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -59,8 +59,16 @@ impl Interpreter {
                     .aliases_for_builtins
                     .get_command_and_args_from_path(&user_input) {
                 None => user_input,
-                Some((path, args)) => TreePath::reconstruct_argumented_path(self.aliases_for_builtins.get_by_path(&path).unwrap().value.clone(), args).unwrap_or(String::from("ERROR: alias and builtin argument counts are different!")),
+                Some((path, args)) => {
+                    if self.aliases_for_builtins.does_node_exist(&path) {
+                        TreePath::reconstruct_argumented_path(self.aliases_for_builtins.get_by_path(&path).unwrap().value.clone(), args).unwrap_or(String::from("ERROR: alias and builtin argument counts are different!"))
+                    }
+                    else {
+                        user_input
+                    }
+                },
             };
+
             match self
                 .builtin_commands
                 .get_command_and_args_from_path(&command_to_invoke)
@@ -72,8 +80,16 @@ impl Interpreter {
                     );
                 }
                 Some((path, args)) => {
-                    let cmd = self.builtin_commands.get_by_path(&path).unwrap();
-                    cmd.value.execute(args);
+                    if self.builtin_commands.does_node_exist(&path) {
+                        let cmd = self.builtin_commands.get_by_path(&path).unwrap();
+                        cmd.value.execute(args);
+                    }
+                    else {
+                        println!(
+                            "{}: command does not exist.",
+                            TreePath::prettify(command_to_invoke.as_str())
+                        );
+                    }
                 }
             }
         }

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -121,8 +121,10 @@ where
             let mut new_arg: Vec<String> = vec![];
             new_arg.extend_from_slice(&nodes[lower_index..=upper_index]);
             let mut new_arg = new_arg.join(" ");
+
             new_arg.remove(0);
             new_arg.remove(new_arg.len() - 1);
+
             args.push(new_arg);
         }
 
@@ -172,6 +174,10 @@ where
                     return None;
                 }
             }
+        }
+
+        if args.iter().any(|arg| arg == "\"") {
+            return None;
         }
 
         Some((argumented.join(" "), args))

--- a/src/util/treepath.rs
+++ b/src/util/treepath.rs
@@ -50,14 +50,9 @@ impl TreePath {
             let mut arg_index: usize = 0;
             for node in pathvec.iter_mut() {
                 if node.as_str() == "<ARG>" {
-                    let new_arg: String;
-                    if TreePath::create_path(args[arg_index].as_str()).len() > 1 {
-                        new_arg = format!("\"{}\"", args[arg_index]).to_string();
-                    }
-                    else {
-                        new_arg = args[arg_index].clone();
-                    }
+                    let new_arg = format!("\"{}\"", args[arg_index]).to_string();
                     *node = new_arg;
+
                     arg_index += 1;
                 }
             }

--- a/src/util/treepath.rs
+++ b/src/util/treepath.rs
@@ -40,4 +40,29 @@ impl TreePath {
             None => None,
         }
     }
+
+    pub fn reconstruct_argumented_path(path_to_reconstruct: String, args: Vec<String>) -> Option<String> {
+        let mut pathvec = TreePath::create_path(path_to_reconstruct.as_str());
+        if pathvec.iter().filter(|node| node.as_str() == "<ARG>").count() != args.len() {
+            None
+        }
+        else {
+            let mut arg_index: usize = 0;
+            for node in pathvec.iter_mut() {
+                if node.as_str() == "<ARG>" {
+                    let new_arg: String;
+                    if TreePath::create_path(args[arg_index].as_str()).len() > 1 {
+                        new_arg = format!("\"{}\"", args[arg_index]).to_string();
+                    }
+                    else {
+                        new_arg = args[arg_index].clone();
+                    }
+                    *node = new_arg;
+                    arg_index += 1;
+                }
+            }
+
+            Some(pathvec.join(" "))
+        }
+    }
 }

--- a/src/util/treepath.rs
+++ b/src/util/treepath.rs
@@ -41,12 +41,19 @@ impl TreePath {
         }
     }
 
-    pub fn reconstruct_argumented_path(path_to_reconstruct: String, args: Vec<String>) -> Option<String> {
+    pub fn reconstruct_argumented_path(
+        path_to_reconstruct: String,
+        args: Vec<String>,
+    ) -> Option<String> {
         let mut pathvec = TreePath::create_path(path_to_reconstruct.as_str());
-        if pathvec.iter().filter(|node| node.as_str() == "<ARG>").count() != args.len() {
+        if pathvec
+            .iter()
+            .filter(|node| node.as_str() == "<ARG>")
+            .count()
+            != args.len()
+        {
             None
-        }
-        else {
+        } else {
             let mut arg_index: usize = 0;
             for node in pathvec.iter_mut() {
                 if node.as_str() == "<ARG>" {


### PR DESCRIPTION
Aliases for builtin commands have been implemented.

**NOTE:** The aliases are still inaccessible via the interpreter interface to the user, they are only in code and act as builtins themselves. The next immediate step after this is to implement builtin commands for adding and removing aliases manually from the Violet shell.