### PR TITLE
[#3] Implemented shell commands for adding and removing command aliases.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ const VIOLET_VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
 const VIOLET_AUTHOR: Option<&'static str> = option_env!("CARGO_PKG_AUTHORS");
 const VIOLET_PROMPT: &str = "<<VIO>>";
 const VIOLET_NAME: Option<&'static str> = option_env!("CARGO_PKG_NAME");
+const VIOLET_EXIT_MESSAGE: &str = "Bye! AYAYA ^_^";
 
 pub fn get_violet_version() -> String {
     VIOLET_VERSION.unwrap_or(VIOLET_UNKNOWN).to_owned()
@@ -20,4 +21,8 @@ pub fn get_violet_prompt() -> String {
 
 pub fn get_violet_name() -> String {
     clone_uppercased(VIOLET_NAME.unwrap_or(VIOLET_UNKNOWN))
+}
+
+pub fn get_exit_message() -> String {
+    format!("{}", VIOLET_EXIT_MESSAGE)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,5 +24,5 @@ pub fn get_violet_name() -> String {
 }
 
 pub fn get_exit_message() -> String {
-    format!("{}", VIOLET_EXIT_MESSAGE)
+    VIOLET_EXIT_MESSAGE.to_string()
 }

--- a/src/control/commands.rs
+++ b/src/control/commands.rs
@@ -92,7 +92,7 @@ impl Action for AddAliasCommand {
         }
 
         if args[0].is_empty() {
-            return Err(InterpretationError::ArgumentEmpty {argument_name: format!("{}", "alias")});
+            return Err(InterpretationError::ArgumentEmpty {argument_name: format!("{}", "alias to add")});
         }
         if args[1].is_empty() {
             return Err(InterpretationError::ArgumentEmpty {argument_name: format!("{}", "builtin name")});
@@ -108,6 +108,10 @@ impl Action for RemoveAliasCommand {
     fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
         if args.len() != 1 {
             return Err(InterpretationError::WrongArgumentCount {expected: 1, actual: args.len()});
+        }
+
+        if args[0].is_empty() {
+            return Err(InterpretationError::ArgumentEmpty { argument_name: format!("{}", "alias to remove")});
         }
 
         Ok(InterpretedCommand::RemoveAlias {alias: args[0].clone()})

--- a/src/control/commands.rs
+++ b/src/control/commands.rs
@@ -3,8 +3,8 @@ extern crate enum_dispatch;
 use chrono::Local;
 use enum_dispatch::*;
 
-use crate::config::get_violet_name;
 use crate::config::get_exit_message;
+use crate::config::get_violet_name;
 
 pub enum InterpretedCommand {
     DoNothing,
@@ -14,8 +14,8 @@ pub enum InterpretedCommand {
 }
 
 pub enum InterpretationError {
-    WrongArgumentCount {expected: usize, actual: usize},
-    ArgumentEmpty {argument_name: String},
+    WrongArgumentCount { expected: usize, actual: usize },
+    ArgumentEmpty { argument_name: String },
 }
 
 #[enum_dispatch]
@@ -38,7 +38,9 @@ pub trait Action {
 pub struct ExitCommand;
 impl Action for ExitCommand {
     fn execute(&self, _args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
-        Ok(InterpretedCommand::Exit { exit_message: get_exit_message() })
+        Ok(InterpretedCommand::Exit {
+            exit_message: get_exit_message(),
+        })
     }
 }
 
@@ -71,7 +73,10 @@ impl Action for SayThisAndThatCommand {
     fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
         if args.len() != 2 {
             println!("Something went horribly wrong...");
-            return Err(InterpretationError::WrongArgumentCount { expected: 2, actual: args.len() });
+            return Err(InterpretationError::WrongArgumentCount {
+                expected: 2,
+                actual: args.len(),
+            });
         }
         println!(
             "Gotcha. Saying {} and {}!",
@@ -88,17 +93,27 @@ pub struct AddAliasCommand;
 impl Action for AddAliasCommand {
     fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
         if args.len() != 2 {
-            return Err(InterpretationError::WrongArgumentCount { expected: 2, actual: args.len() });
+            return Err(InterpretationError::WrongArgumentCount {
+                expected: 2,
+                actual: args.len(),
+            });
         }
 
         if args[0].is_empty() {
-            return Err(InterpretationError::ArgumentEmpty {argument_name: format!("{}", "alias to add")});
+            return Err(InterpretationError::ArgumentEmpty {
+                argument_name: "alias to add".to_string(),
+            });
         }
         if args[1].is_empty() {
-            return Err(InterpretationError::ArgumentEmpty {argument_name: format!("{}", "builtin name")});
+            return Err(InterpretationError::ArgumentEmpty {
+                argument_name: "builtin name".to_string(),
+            });
         }
 
-        Ok(InterpretedCommand::AddAlias { alias: args[0].clone(), for_builtin: args[1].clone() })
+        Ok(InterpretedCommand::AddAlias {
+            alias: args[0].clone(),
+            for_builtin: args[1].clone(),
+        })
     }
 }
 
@@ -107,13 +122,20 @@ pub struct RemoveAliasCommand;
 impl Action for RemoveAliasCommand {
     fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
         if args.len() != 1 {
-            return Err(InterpretationError::WrongArgumentCount {expected: 1, actual: args.len()});
+            return Err(InterpretationError::WrongArgumentCount {
+                expected: 1,
+                actual: args.len(),
+            });
         }
 
         if args[0].is_empty() {
-            return Err(InterpretationError::ArgumentEmpty { argument_name: format!("{}", "alias to remove")});
+            return Err(InterpretationError::ArgumentEmpty {
+                argument_name: "alias to remove".to_string(),
+            });
         }
 
-        Ok(InterpretedCommand::RemoveAlias {alias: args[0].clone()})
+        Ok(InterpretedCommand::RemoveAlias {
+            alias: args[0].clone(),
+        })
     }
 }

--- a/src/control/commands.rs
+++ b/src/control/commands.rs
@@ -3,9 +3,19 @@ extern crate enum_dispatch;
 use chrono::Local;
 use enum_dispatch::*;
 
-use std::process::exit;
-
 use crate::config::get_violet_name;
+use crate::config::get_exit_message;
+
+pub enum InterpretedCommand {
+    DoNothing,
+    Exit { exit_message: String },
+    AddAlias { alias: String, for_builtin: String},
+    RemoveAlias { alias: String},
+}
+
+pub enum InterpretationError {
+    WrongArgumentCount {expected: usize, actual: usize},
+}
 
 #[enum_dispatch]
 #[derive(Clone)]
@@ -18,49 +28,54 @@ pub enum Command {
 
 #[enum_dispatch(Command)]
 pub trait Action {
-    fn execute(&self, args: Vec<String>);
+    fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError>;
 }
 
 #[derive(Clone)]
 pub struct ExitCommand;
 impl Action for ExitCommand {
-    fn execute(&self, _args: Vec<String>) {
-        println!("BYE! AYAYA ^_^");
-        exit(0);
+    fn execute(&self, _args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
+        Ok(InterpretedCommand::Exit { exit_message: get_exit_message() })
     }
 }
 
 #[derive(Clone)]
 pub struct CurrentTimeCommand;
 impl Action for CurrentTimeCommand {
-    fn execute(&self, _args: Vec<String>) {
+    fn execute(&self, _args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
         println!(
             "Your system clock says it's {} now!",
             Local::now().format("%I:%M %p")
         );
+
+        Ok(InterpretedCommand::DoNothing)
     }
 }
 
 #[derive(Clone)]
 pub struct WhatsYourNameCommand;
 impl Action for WhatsYourNameCommand {
-    fn execute(&self, _args: Vec<String>) {
+    fn execute(&self, _args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
         println!("My name is {}! Nice to meet you ^_^", &get_violet_name());
+
+        Ok(InterpretedCommand::DoNothing)
     }
 }
 
 #[derive(Clone)]
 pub struct SayThisAndThatCommand;
 impl Action for SayThisAndThatCommand {
-    fn execute(&self, args: Vec<String>) {
+    fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
         if args.len() != 2 {
             println!("Something went horribly wrong...");
-            return;
+            return Err(InterpretationError::WrongArgumentCount { expected: 2, actual: args.len() });
         }
         println!(
             "Gotcha. Saying {} and {}!",
             args.get(0).unwrap(),
             args.get(1).unwrap()
         );
+
+        Ok(InterpretedCommand::DoNothing)
     }
 }

--- a/src/control/commands.rs
+++ b/src/control/commands.rs
@@ -9,12 +9,13 @@ use crate::config::get_exit_message;
 pub enum InterpretedCommand {
     DoNothing,
     Exit { exit_message: String },
-    AddAlias { alias: String, for_builtin: String},
-    RemoveAlias { alias: String},
+    AddAlias { alias: String, for_builtin: String },
+    RemoveAlias { alias: String },
 }
 
 pub enum InterpretationError {
     WrongArgumentCount {expected: usize, actual: usize},
+    ArgumentEmpty {argument_name: String},
 }
 
 #[enum_dispatch]
@@ -24,6 +25,8 @@ pub enum Command {
     CurrentTimeCommand,
     WhatsYourNameCommand,
     SayThisAndThatCommand,
+    AddAliasCommand,
+    RemoveAliasCommand,
 }
 
 #[enum_dispatch(Command)]
@@ -77,5 +80,36 @@ impl Action for SayThisAndThatCommand {
         );
 
         Ok(InterpretedCommand::DoNothing)
+    }
+}
+
+#[derive(Clone)]
+pub struct AddAliasCommand;
+impl Action for AddAliasCommand {
+    fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
+        if args.len() != 2 {
+            return Err(InterpretationError::WrongArgumentCount { expected: 2, actual: args.len() });
+        }
+
+        if args[0].is_empty() {
+            return Err(InterpretationError::ArgumentEmpty {argument_name: format!("{}", "alias")});
+        }
+        if args[1].is_empty() {
+            return Err(InterpretationError::ArgumentEmpty {argument_name: format!("{}", "builtin name")});
+        }
+
+        Ok(InterpretedCommand::AddAlias { alias: args[0].clone(), for_builtin: args[1].clone() })
+    }
+}
+
+#[derive(Clone)]
+pub struct RemoveAliasCommand;
+impl Action for RemoveAliasCommand {
+    fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
+        if args.len() != 1 {
+            return Err(InterpretationError::WrongArgumentCount {expected: 1, actual: args.len()});
+        }
+
+        Ok(InterpretedCommand::RemoveAlias {alias: args[0].clone()})
     }
 }

--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -31,7 +31,10 @@ impl Interpreter {
             Command::from(SayThisAndThatCommand),
             "please say <ARG> and <ARG>",
         );
-        builtins.set_by_path(Command::from(AddAliasCommand), "add alias <ARG> for builtin <ARG>");
+        builtins.set_by_path(
+            Command::from(AddAliasCommand),
+            "add alias <ARG> for builtin <ARG>",
+        );
         builtins.set_by_path(Command::from(RemoveAliasCommand), "remove alias <ARG>");
     }
 
@@ -42,7 +45,10 @@ impl Interpreter {
 
     fn add_alias(&mut self, alias: String, for_builtin: String) {
         if !self.builtin_commands.does_node_exist(&for_builtin) {
-            println!("ERROR: Can't set alias, builtin command [{}] does not exist!", for_builtin);
+            println!(
+                "ERROR: Can't set alias, builtin command [{}] does not exist!",
+                for_builtin
+            );
             return;
         }
 
@@ -56,28 +62,46 @@ impl Interpreter {
             return;
         }
 
-        if TreePath::create_path(&alias).iter().filter(|node| node.as_str() == "<ARG>").count() != TreePath::create_path(&for_builtin).iter().filter(|node| node.as_str() == "<ARG>").count() {
-            println!("ERROR: alias and the builtin command have to have an equal number of arguments!");
+        if TreePath::create_path(&alias)
+            .iter()
+            .filter(|node| node.as_str() == "<ARG>")
+            .count()
+            != TreePath::create_path(&for_builtin)
+                .iter()
+                .filter(|node| node.as_str() == "<ARG>")
+                .count()
+        {
+            println!(
+                "ERROR: alias and the builtin command have to have an equal number of arguments!"
+            );
             return;
         }
 
-        self.aliases_for_builtins.set_by_path(for_builtin, alias.as_str());
+        self.aliases_for_builtins
+            .set_by_path(for_builtin, alias.as_str());
     }
 
     fn remove_alias(&mut self, alias: String) {
         if self.builtin_commands.does_node_exist(&alias) {
-            println!("ERROR: you can't remove a builtin command. Choose an alias to remove instead.");
+            println!(
+                "ERROR: you can't remove a builtin command. Choose an alias to remove instead."
+            );
             return;
         }
 
         if !self.aliases_for_builtins.does_node_exist(&alias) {
-            println!("ERROR: alias [{}] does not exist. Can't remove alias which doesn't exist.", &alias);
+            println!(
+                "ERROR: alias [{}] does not exist. Can't remove alias which doesn't exist.",
+                &alias
+            );
             return;
         }
 
         match self.aliases_for_builtins.drop_by_path(&alias) {
             Ok(PathTreeOk::DropOk) => (),
-            Err(PathTreeErr::DropNodeDoesNotExist) => println!("ERROR: PathTree: node [{}] does not exist!", &alias)
+            Err(PathTreeErr::DropNodeDoesNotExist) => {
+                println!("ERROR: PathTree: node [{}] does not exist!", &alias)
+            }
         };
     }
 
@@ -110,9 +134,9 @@ impl Interpreter {
                                 .clone(),
                             args,
                         )
-                        .unwrap_or_else(|| String::from(
-                            "ERROR: keyword <ARG> used in the wrong context, or",
-                        ))
+                        .unwrap_or_else(|| {
+                            String::from("ERROR: keyword <ARG> used in the wrong context, or")
+                        })
                     } else {
                         user_input
                     }

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -2,11 +2,11 @@ use crate::util::treepath::TreePath;
 use std::collections::HashMap;
 
 pub enum PathTreeOk {
-    DropOk
+    DropOk,
 }
 
 pub enum PathTreeErr {
-    DropNodeDoesNotExist
+    DropNodeDoesNotExist,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -65,8 +65,7 @@ where
         if self.does_node_exist(path) {
             self.tree.remove(path).unwrap();
             Ok(PathTreeOk::DropOk)
-        }
-        else {
+        } else {
             Err(PathTreeErr::DropNodeDoesNotExist)
         }
     }

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -1,6 +1,14 @@
 use crate::util::treepath::TreePath;
 use std::collections::HashMap;
 
+pub enum PathTreeOk {
+    DropOk
+}
+
+pub enum PathTreeErr {
+    DropNodeDoesNotExist
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct Node<T> {
     pub value: T,
@@ -50,6 +58,16 @@ where
             node_option.as_ref()
         } else {
             None
+        }
+    }
+
+    pub fn drop_by_path(&mut self, path: &str) -> Result<PathTreeOk, PathTreeErr> {
+        if self.does_node_exist(path) {
+            self.tree.remove(path).unwrap();
+            Ok(PathTreeOk::DropOk)
+        }
+        else {
+            Err(PathTreeErr::DropNodeDoesNotExist)
         }
     }
 


### PR DESCRIPTION
There are two new commands in the shell now:
`add alias <ARG> for bulitin <ARG>`
and
`remove alias <ARG>`

Alias names are not limited in any way, except of the obvious stuff like:
- You can't remove a non-existing alias;
- You can't add alias that already exists;
- You can't add alias that looks exactly like a builtin command;
- You can't have empty arguments (\"\") in those two commands.

We have to use quotes when specifying commands. Also, for builtins with arguments, an equal number of arguments must be specified. For example:
- `add alias "blabber <ARG> and <ARG>" for builtin "please say <ARG> and <ARG>"` is a valid command, as the argument counts are equal and the builtin command exists;
- `add alias "go <ARG> away" for builtin "exit"` is an invalid command, as alias has 1 argument, while the builtin "exit" has 0 arguments.