### PR TITLE
[#2] Implemented the shortcut mechanism for builtin commands.

### DIFF
--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -53,18 +53,18 @@ impl Interpreter {
     }
 
     fn set_all_builtins(builtins: &mut PathTree<Command>) {
-        builtins.set_by_path(Command::from(ExitCommand), "exit");
-        builtins.set_by_path(Command::from(CurrentTimeCommand), "what time is it");
-        builtins.set_by_path(Command::from(WhatsYourNameCommand), "what is your name");
-        builtins.set_by_path(
+        builtins.set_by_path_with_shortcut(Command::from(ExitCommand), "exit");
+        builtins.set_by_path_with_shortcut(Command::from(CurrentTimeCommand), "what time is it");
+        builtins.set_by_path_with_shortcut(Command::from(WhatsYourNameCommand), "what is your name");
+        builtins.set_by_path_with_shortcut(
             Command::from(SayThisAndThatCommand),
             "please say <ARG> and <ARG>",
         );
-        builtins.set_by_path(
+        builtins.set_by_path_with_shortcut(
             Command::from(AddAliasCommand),
             "add alias <ARG> for builtin <ARG>",
         );
-        builtins.set_by_path(Command::from(RemoveAliasCommand), "remove alias <ARG>");
+        builtins.set_by_path_with_shortcut(Command::from(RemoveAliasCommand), "remove alias <ARG>");
     }
 
     fn exit(&mut self, exit_message: String) {
@@ -116,14 +116,8 @@ impl Interpreter {
             return;
         }
 
-        if TreePath::create_path(&alias)
-            .iter()
-            .filter(|node| node.as_str() == "<ARG>")
-            .count()
-            != TreePath::create_path(&for_builtin)
-                .iter()
-                .filter(|node| node.as_str() == "<ARG>")
-                .count()
+        if TreePath::count_x_nodes_for_path(&alias, "<ARG>")
+            != TreePath::count_x_nodes_for_path(&for_builtin, "<ARG>")
         {
             println!(
                 "ERROR: alias and the builtin command have to have an equal number of arguments!"

--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -55,7 +55,8 @@ impl Interpreter {
     fn set_all_builtins(builtins: &mut PathTree<Command>) {
         builtins.set_by_path_with_shortcut(Command::from(ExitCommand), "exit");
         builtins.set_by_path_with_shortcut(Command::from(CurrentTimeCommand), "what time is it");
-        builtins.set_by_path_with_shortcut(Command::from(WhatsYourNameCommand), "what is your name");
+        builtins
+            .set_by_path_with_shortcut(Command::from(WhatsYourNameCommand), "what is your name");
         builtins.set_by_path_with_shortcut(
             Command::from(SayThisAndThatCommand),
             "please say <ARG> and <ARG>",

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -55,6 +55,12 @@ where
             })
     }
 
+    pub fn set_by_path_with_shortcut(&mut self, value: T, path: &str) {
+        self.set_by_path(value.clone(), path);
+
+        self.set_by_path(value, TreePath::create_shortcut(path).as_str());
+    }
+
     pub fn get_by_path(&self, path: &str) -> Option<&Node<T>> {
         let path = TreePath::create_path(&path);
         if let Some(node_option) = self.tree.get(&path.join(" ")) {

--- a/src/util/treepath.rs
+++ b/src/util/treepath.rs
@@ -89,9 +89,8 @@ impl TreePath {
                 shortcut.push('a');
                 arg_count += 1;
             } else {
-                shortcut.push(node.chars().nth(0).unwrap());
+                shortcut.push(node.chars().next().unwrap());
             }
-
         }
 
         shortcut.push(']');

--- a/src/util/treepath.rs
+++ b/src/util/treepath.rs
@@ -67,4 +67,38 @@ impl TreePath {
             Some(pathvec.join(" "))
         }
     }
+
+    pub fn count_x_nodes_for_path(path: &str, x_node: &str) -> usize {
+        TreePath::create_path(path)
+            .iter()
+            .filter(|node| node.as_str() == x_node)
+            .count()
+    }
+
+    pub fn create_shortcut(path: &str) -> String {
+        if path.is_empty() {
+            panic!("PANIC: TreePath::create_shortcut(): couldn't create the shortcut, source path is empty!");
+        }
+
+        let pathvec = TreePath::create_path(path);
+        let mut shortcut: String = String::from('[');
+        let mut arg_count: usize = 0;
+
+        for node in pathvec {
+            if node.as_str() == "<ARG>" {
+                shortcut.push('a');
+                arg_count += 1;
+            } else {
+                shortcut.push(node.chars().nth(0).unwrap());
+            }
+
+        }
+
+        shortcut.push(']');
+        if arg_count != 0 {
+            shortcut.push(' ');
+            shortcut.push_str(vec!["<ARG>"; arg_count].join(" ").as_str());
+        }
+        shortcut
+    }
 }


### PR DESCRIPTION
As initially expected, the design for a shortcut is:
- for any node but `<ARG>`, the shortcut is the first letter of the node name.
- for `<ARG>`, the shortcut is `a`.
- This is all enclosed by `[]`.

With this said, examples:
- Shortcut for builtin `exit` is `[e]`;
- Shortcut for builtin `what is your name` is `[wiyn]`;
- Shortcut for builtin `remove alias <ARG>` is `[raa] <ARG>`;
- Shortcut for builtin `add alias <ARG> for builtin <ARG>` is `[aaafba] <ARG> <ARG>`;
- Shortuct for builtin `please say <ARG> and <ARG>` is `[psaaa] <ARG> <ARG>`.