### PR TITLE
[#5] Implemented generating sequential shortcuts if the default shortcut is already taken.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,36 @@ Shortcut for
 <<VIO>> remove alias \"alias for exit\"
 is
 <<VIO>> [raa] \"alias for exit\"
+---
+If the same shortcut is created several times due to name collision, the second and subsequent shortcuts are appended with a sequential number.
+Example:
+Assume we have three [eaa] commands, and they were added in this order:
+1. enable alias <ARG>
+2. exists argument <ARG>
+3. eat ate <ARG>
+Three aliases would be created for that:
+- [eaa] <ARG>, which calls enable alias <ARG>;
+- [eaa2] <ARG>, which calls exists argument <ARG>;
+- [eaa3] <ARG>, which calls eat <ARG> <ARG>.
+---
+NOTE: aliases with different arity (number of argument) are considered different commands. Therefore, if we have:
+1. enable alias <ARG> // arity 1
+2. eat <ARG> <ARG> // arity 2
+The aliases created are going to be:
+- [eaa] <ARG> // for enable alias <ARG>
+- [eaa] <ARG> <ARG> // for eat <ARG> <ARG>
+NOTE: there are no sequential numbers like [eaa2] here. The reason is the different arities of the two commands.
+---
+You can see what a certain shortcut expands to with \"explain command <ARG>\":
+Example: if you have two commands with the [eca] shortcut name, \"explain command <ARG>\" and \"eat candy <ARG>\"
+<<VIO>> explain command \"[eca] <ARG>\"
+  [[help for explain command <ARG>]]
+<<VIO>> explain command \"[eca2] <ARG>\"
+  [[help for eat candy <ARG>]]
+---
+You can of course use shortcuts while meta-asking for explanation about explanation:
+<<VIO>> [eca] \"[eca] <ARG>\"
+  [[help for explain command <ARG>]]
 ";
 
 pub struct Help;
@@ -161,7 +191,7 @@ impl Help {
 
     pub fn help() -> &'static str {
         "<<VIO>> help
-        \tA concise yet information-dense intro to the basics of Violet.
+          A concise yet information-dense intro to the basics of Violet.
         "
     }
 }

--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -80,7 +80,7 @@ impl Interpreter {
     fn exit(&mut self, exit_message: String) {
         if !self.aliases_for_builtins.tree.is_empty() {
             match std::fs::File::create(config::get_config_file_name()) {
-                Ok(file) => match serde_json::to_writer(file, &self.aliases_for_builtins) {
+                Ok(file) => match serde_json::to_writer_pretty(file, &self.aliases_for_builtins) {
                     Ok(()) => println!("INFO: saved aliases successfully before exiting ^_^"),
                     Err(the_err) => println!(
                         "ERROR: opened file, but weren't able to save aliases to it: {:?}",

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -58,7 +58,21 @@ where
     pub fn set_by_path_with_shortcut(&mut self, value: T, path: &str) {
         self.set_by_path(value.clone(), path);
 
-        self.set_by_path(value, TreePath::create_shortcut(path).as_str());
+        let mut shortcut_name = TreePath::create_shortcut(path, 1);
+        if !self.does_node_exist(&shortcut_name) {
+            self.set_by_path(value.clone(), &shortcut_name);
+        } else {
+            let mut alias_serial_number: usize = 2;
+            shortcut_name = loop {
+                let current_alias = TreePath::create_shortcut(path, alias_serial_number);
+                if !self.does_node_exist(&current_alias) {
+                    break current_alias;
+                } else {
+                    alias_serial_number += 1;
+                }
+            }
+        }
+        self.set_by_path(value, &shortcut_name);
     }
 
     pub fn get_by_path(&self, path: &str) -> Option<&Node<T>> {

--- a/src/util/treepath.rs
+++ b/src/util/treepath.rs
@@ -85,7 +85,11 @@ impl TreePath {
         let mut arg_count: usize = 0;
 
         let serial_str = serial.to_string();
-        let alias_serial = if serial_str.as_str() == "1" { "" } else { serial_str.as_str() };
+        let alias_serial = if serial_str.as_str() == "1" {
+            ""
+        } else {
+            serial_str.as_str()
+        };
 
         for node in pathvec {
             if node.as_str() == "<ARG>" {

--- a/src/util/treepath.rs
+++ b/src/util/treepath.rs
@@ -75,7 +75,7 @@ impl TreePath {
             .count()
     }
 
-    pub fn create_shortcut(path: &str) -> String {
+    pub fn create_shortcut(path: &str, serial: usize) -> String {
         if path.is_empty() {
             panic!("PANIC: TreePath::create_shortcut(): couldn't create the shortcut, source path is empty!");
         }
@@ -83,6 +83,9 @@ impl TreePath {
         let pathvec = TreePath::create_path(path);
         let mut shortcut: String = String::from('[');
         let mut arg_count: usize = 0;
+
+        let serial_str = serial.to_string();
+        let alias_serial = if serial_str.as_str() == "1" { "" } else { serial_str.as_str() };
 
         for node in pathvec {
             if node.as_str() == "<ARG>" {
@@ -93,6 +96,9 @@ impl TreePath {
             }
         }
 
+        if !alias_serial.is_empty() {
+            shortcut.push_str(alias_serial);
+        }
         shortcut.push(']');
         if arg_count != 0 {
             shortcut.push(' ');


### PR DESCRIPTION
Instead of letting the user choose which command to run based on a single alias (example: user inputs [e] and Violet lets them choose between exit and edit) as it had been originally intended, the shortcuts are implemented in a way where if there's already a shortcut with a certain name ([e]), the new shortcut is going to be created with a alternative sequential name ([e2], [e3] etc.).