### PR TITLE
[#37] Fixed problems with the WrongArgumentCount error.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,13 @@ const VIOLET_NAME: Option<&'static str> = option_env!("CARGO_PKG_NAME");
 const VIOLET_EXIT_MESSAGE: &str = "Bye! AYAYA ^_^";
 const VIOLET_CONFIG_FILE_NAME: &str = "./config.json";
 
+#[macro_export]
+macro_rules! argcount_err { () => {
+        "ERROR: Wrong argument count; expected {}, found {}!\n\nNOTE: This sometimes happens when you put the <ARG> argument specifier directly into the command as an argument.\n      If you did that, please specify an actual argument instead.\n      Passing <ARG> as a single self-contained argument without quotation marks (like this: please say <ARG> and <ARG>) to a command is considered a mistake on the user's side.\nExample: instead of\n<<VIO>> explain command <ARG>\n  please use\n<<VIO>> explain command help\n"
+    }
+}
+
+
 const VIOLET_HELP_MESSAGE: &str = "Violet is a command interpreter.
 When you see the \"<<VIO>> \" prompt, it means you can enter your command and press <ENTER>.
 ---
@@ -84,7 +91,7 @@ Three aliases would be created for that:
 - [eaa2] <ARG>, which calls exists argument <ARG>;
 - [eaa3] <ARG>, which calls eat <ARG> <ARG>.
 ---
-NOTE: aliases with different arity (number of argument) are considered different commands. Therefore, if we have:
+NOTE: aliases with different arity (number of arguments) are considered different commands. Therefore, if we have:
 1. enable alias <ARG> // arity 1
 2. eat <ARG> <ARG> // arity 2
 The aliases created are going to be:

--- a/src/control/commands.rs
+++ b/src/control/commands.rs
@@ -94,7 +94,6 @@ pub struct SayThisAndThatCommand;
 impl Action for SayThisAndThatCommand {
     fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
         if args.len() != 2 {
-            println!("Something went horribly wrong...");
             return Err(InterpretationError::WrongArgumentCount {
                 expected: 2,
                 actual: args.len(),
@@ -204,6 +203,13 @@ impl Action for ListAvailableCommandsCommand {
 pub struct ExplainCommandCommand;
 impl Action for ExplainCommandCommand {
     fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
+        if args.len() != 1 {
+            return Err(InterpretationError::WrongArgumentCount {
+                expected: 1,
+                actual: args.len(),
+            });
+        }
+
         if args[0].is_empty() {
             return Err(InterpretationError::ArgumentEmpty {
                 argument_name: "command to explain".to_string(),

--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -1,4 +1,5 @@
 use crate::config;
+use crate::argcount_err;
 use crate::data::pathtree::*;
 use crate::io::input;
 use crate::util::string::clone_uppercased;
@@ -263,7 +264,7 @@ impl Interpreter {
                             Ok(InterpretedCommand::RemoveAlias {alias}) => self.remove_alias(alias),
                             Ok(InterpretedCommand::ExplainCommand {command}) => self.explain_command(&command),
 
-                            Err(InterpretationError::WrongArgumentCount { expected, actual}) => println!("ERROR: Wrong argument count; expected {}, found {}!", expected, actual),
+                            Err(InterpretationError::WrongArgumentCount { expected, actual}) => println!(argcount_err!(), expected, actual),
                             Err(InterpretationError::ArgumentEmpty {argument_name}) => println!("ERROR: Argument named [{}] is empty, which is not allowed in this context!", argument_name),
                         }
                     } else {


### PR DESCRIPTION
- Added message explaining that `<ARG>` should not be used directly in a command;
- Started actually using Rust macros;
- Fixed panic/crash in ExplainCommandCommand due to not handling the direct passing of `<ARG>` to the command with WrongArgumentCount.