### PR TITLE
[#44] Refactored `HashMap<String, Option<Node<T>>` to `HashMap<String, Node<T>` and value to `Option<T>`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,6 @@ macro_rules! argcount_err { () => {
     }
 }
 
-
 const VIOLET_HELP_MESSAGE: &str = "Violet is a command interpreter.
 When you see the \"<<VIO>> \" prompt, it means you can enter your command and press <ENTER>.
 ---

--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -112,7 +112,7 @@ impl Interpreter {
         if !self.builtin_commands.tree.is_empty() {
             println!("Available commands:\n");
             for key in self.builtin_commands.tree.keys() {
-                if self.builtin_commands.does_node_exist(key) && !TreePath::is_path_a_shortcut(&key)
+                if self.builtin_commands.does_node_contain_value(key) && !TreePath::is_path_a_shortcut(&key)
                 {
                     println!("- {};", key);
                 }
@@ -124,7 +124,7 @@ impl Interpreter {
     }
 
     fn explain_command(&mut self, command: &str) {
-        if !self.builtin_commands.does_node_exist(command) {
+        if !self.builtin_commands.does_node_contain_value(command) {
             println!(
                 "ERROR: can't explain command \"{}\" which doesn't exist.",
                 command
@@ -145,7 +145,7 @@ impl Interpreter {
     }
 
     fn add_alias(&mut self, alias: String, for_builtin: String) {
-        if !self.builtin_commands.does_node_exist(&for_builtin) {
+        if !self.builtin_commands.does_node_contain_value(&for_builtin) {
             println!(
                 "ERROR: Can't set alias, builtin command [{}] does not exist!",
                 for_builtin
@@ -153,12 +153,12 @@ impl Interpreter {
             return;
         }
 
-        if self.builtin_commands.does_node_exist(&alias) {
+        if self.builtin_commands.does_node_contain_value(&alias) {
             println!("ERROR: can't set this alias: [{}] is an existing builtin command name. Choose a different name for the alias.", alias);
             return;
         }
 
-        if self.aliases_for_builtins.does_node_exist(&alias) {
+        if self.aliases_for_builtins.does_node_contain_value(&alias) {
             println!("ERROR: Can't set this alias, alias [{}] already exists. Remove the existing one first!", alias);
             return;
         }
@@ -177,14 +177,14 @@ impl Interpreter {
     }
 
     fn remove_alias(&mut self, alias: String) {
-        if self.builtin_commands.does_node_exist(&alias) {
+        if self.builtin_commands.does_node_contain_value(&alias) {
             println!(
                 "ERROR: you can't remove a builtin command. Choose an alias to remove instead."
             );
             return;
         }
 
-        if !self.aliases_for_builtins.does_node_exist(&alias) {
+        if !self.aliases_for_builtins.does_node_contain_value(&alias) {
             println!(
                 "ERROR: alias [{}] does not exist. Can't remove alias which doesn't exist.",
                 &alias
@@ -227,7 +227,7 @@ impl Interpreter {
             {
                 None => user_input,
                 Some((path, args)) => {
-                    if self.aliases_for_builtins.does_node_exist(&path) {
+                    if self.aliases_for_builtins.does_node_contain_value(&path) {
                         TreePath::reconstruct_argumented_path(
                             &self.aliases_for_builtins
                                 .get_by_path(&path)
@@ -257,7 +257,7 @@ impl Interpreter {
                     );
                 }
                 Some((path, args)) => {
-                    if self.builtin_commands.does_node_exist(&path) {
+                    if self.builtin_commands.does_node_contain_value(&path) {
                         let node = self.builtin_commands.get_by_path(&path).unwrap();
                         match node.clone().value.unwrap().execute(args) {
                             Ok(InterpretedCommand::DoNothing) => (),

--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -137,7 +137,9 @@ impl Interpreter {
             self.builtin_commands
                 .get_by_path(command)
                 .unwrap()
+                .to_owned()
                 .value
+                .unwrap()
                 .help()
         );
     }
@@ -227,11 +229,12 @@ impl Interpreter {
                 Some((path, args)) => {
                     if self.aliases_for_builtins.does_node_exist(&path) {
                         TreePath::reconstruct_argumented_path(
-                            self.aliases_for_builtins
+                            &self.aliases_for_builtins
                                 .get_by_path(&path)
                                 .unwrap()
+                                .to_owned()
                                 .value
-                                .clone(),
+                                .unwrap(),
                             args,
                         )
                         .unwrap_or_else(|| {
@@ -255,8 +258,8 @@ impl Interpreter {
                 }
                 Some((path, args)) => {
                     if self.builtin_commands.does_node_exist(&path) {
-                        let cmd = self.builtin_commands.get_by_path(&path).unwrap();
-                        match cmd.value.execute(args) {
+                        let node = self.builtin_commands.get_by_path(&path).unwrap();
+                        match node.clone().value.unwrap().execute(args) {
                             Ok(InterpretedCommand::DoNothing) => (),
                             Ok(InterpretedCommand::ListAvailableCommands) => self.list_available_commands(),
                             Ok(InterpretedCommand::Exit { exit_message}) => self.exit(exit_message),

--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -1,5 +1,5 @@
-use crate::config;
 use crate::argcount_err;
+use crate::config;
 use crate::data::pathtree::*;
 use crate::io::input;
 use crate::util::string::clone_uppercased;
@@ -112,7 +112,8 @@ impl Interpreter {
         if !self.builtin_commands.tree.is_empty() {
             println!("Available commands:\n");
             for key in self.builtin_commands.tree.keys() {
-                if self.builtin_commands.does_node_contain_value(key) && !TreePath::is_path_a_shortcut(&key)
+                if self.builtin_commands.does_node_contain_value(key)
+                    && !TreePath::is_path_a_shortcut(&key)
                 {
                     println!("- {};", key);
                 }
@@ -229,7 +230,8 @@ impl Interpreter {
                 Some((path, args)) => {
                     if self.aliases_for_builtins.does_node_contain_value(&path) {
                         TreePath::reconstruct_argumented_path(
-                            &self.aliases_for_builtins
+                            &self
+                                .aliases_for_builtins
                                 .get_by_path(&path)
                                 .unwrap()
                                 .to_owned()

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -13,12 +13,12 @@ pub enum PathTreeErr {
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Node<T> {
-    pub value: T,
+    pub value: Option<T>,
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct PathTree<T> {
-    pub tree: HashMap<String, Option<Node<T>>>,
+    pub tree: HashMap<String, Node<T>>,
 }
 
 impl<T> PathTree<T>
@@ -45,12 +45,12 @@ where
                 if index == path.len() - 1 {
                     self.tree.insert(
                         one_path,
-                        Some(Node {
-                            value: value.to_owned(),
-                        }),
+                        Node {
+                            value: Some(value.to_owned()),
+                        },
                     );
                 } else {
-                    self.tree.entry(one_path).or_insert(None);
+                    self.tree.entry(one_path).or_insert(Node { value: None });
                 }
             })
     }
@@ -77,11 +77,8 @@ where
 
     pub fn get_by_path(&self, path: &str) -> Option<&Node<T>> {
         let path = TreePath::create_path(&path);
-        if let Some(node_option) = self.tree.get(&path.join(" ")) {
-            node_option.as_ref()
-        } else {
-            None
-        }
+
+        self.tree.get(&path.join(" "))
     }
 
     pub fn drop_by_path(&mut self, path: &str) -> Result<PathTreeOk, PathTreeErr> {
@@ -309,7 +306,7 @@ fn test_tree_setters_and_getters() {
     );
     assert_eq!(
         Some(&Node {
-            value: String::from("test garbage val")
+            value: Some(String::from("test garbage val"))
         }),
         test_tree.get_by_path("そっか おふの $%?рашин /fourth .fifth \\sixth")
     );
@@ -364,7 +361,7 @@ fn test_pathing_works_with_untrimmed_paths() {
     assert_eq!(None, test_tree.get_by_path("something completely"));
     assert_eq!(
         Some(&Node {
-            value: String::from("test garbage val")
+            value: Some(String::from("test garbage val"))
         }),
         test_tree.get_by_path("something completely bonkers")
     );

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -267,7 +267,10 @@ fn test_tree_setters_and_getters() {
     assert_eq!(true, test_tree.does_path_exist("そっか"));
     assert_eq!(false, test_tree.does_node_contain_value("そっか おふの"));
     assert_eq!(true, test_tree.does_path_exist("そっか おふの"));
-    assert_eq!(false, test_tree.does_node_contain_value("そっか おふの $%?рашин"));
+    assert_eq!(
+        false,
+        test_tree.does_node_contain_value("そっか おふの $%?рашин")
+    );
     assert_eq!(true, test_tree.does_path_exist("そっか おふの $%?рашин"));
     assert_eq!(
         false,
@@ -295,14 +298,26 @@ fn test_tree_setters_and_getters() {
     );
     assert_eq!(None, test_tree.get_by_path("そっか").unwrap().value);
     assert_eq!(None, test_tree.get_by_path("そっか おふの").unwrap().value);
-    assert_eq!(None, test_tree.get_by_path("そっか おふの $%?рашин").unwrap().value);
     assert_eq!(
         None,
-        test_tree.get_by_path("そっか おふの $%?рашин /fourth").unwrap().value
+        test_tree
+            .get_by_path("そっか おふの $%?рашин")
+            .unwrap()
+            .value
     );
     assert_eq!(
         None,
-        test_tree.get_by_path("そっか おふの $%?рашин /fourth .fifth").unwrap().value
+        test_tree
+            .get_by_path("そっか おふの $%?рашин /fourth")
+            .unwrap()
+            .value
+    );
+    assert_eq!(
+        None,
+        test_tree
+            .get_by_path("そっか おふの $%?рашин /fourth .fifth")
+            .unwrap()
+            .value
     );
     assert_eq!(
         Some(&Node {
@@ -346,7 +361,10 @@ fn test_pathing_works_with_untrimmed_paths() {
 
     assert_eq!(false, test_tree.does_node_contain_value("something"));
     assert_eq!(true, test_tree.does_path_exist("something"));
-    assert_eq!(false, test_tree.does_node_contain_value("something completely"));
+    assert_eq!(
+        false,
+        test_tree.does_node_contain_value("something completely")
+    );
     assert_eq!(true, test_tree.does_path_exist("something completely"));
     assert_eq!(
         true,
@@ -358,7 +376,10 @@ fn test_pathing_works_with_untrimmed_paths() {
     );
 
     assert_eq!(None, test_tree.get_by_path("something").unwrap().value);
-    assert_eq!(None, test_tree.get_by_path("something completely").unwrap().value);
+    assert_eq!(
+        None,
+        test_tree.get_by_path("something completely").unwrap().value
+    );
     assert_eq!(
         Some(&Node {
             value: Some(String::from("test garbage val"))

--- a/src/util/treepath.rs
+++ b/src/util/treepath.rs
@@ -42,10 +42,10 @@ impl TreePath {
     }
 
     pub fn reconstruct_argumented_path(
-        path_to_reconstruct: String,
+        path_to_reconstruct: &str,
         args: Vec<String>,
     ) -> Option<String> {
-        let mut pathvec = TreePath::create_path(path_to_reconstruct.as_str());
+        let mut pathvec = TreePath::create_path(path_to_reconstruct);
         if pathvec
             .iter()
             .filter(|node| node.as_str() == "<ARG>")


### PR DESCRIPTION
As planned in the original issue, this PR changes `Option<Node<T>>` stored in the `PathTree` `HashMap` to `Node<T>`, and the value inside of `Node<T>` from just `T` to `Option<T>`.