### PR TITLE
[#48] Fixed difference in behavior between aliases and builtins when using the `<ARG>` specifier directly

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -8,13 +8,10 @@ const VIOLET_NAME: Option<&'static str> = option_env!("CARGO_PKG_NAME");
 const VIOLET_EXIT_MESSAGE: &str = "Bye! AYAYA ^_^";
 const VIOLET_CONFIG_FILE_NAME: &str = "./config.json";
 
-#[macro_export]
-macro_rules! argcount_err { () => {
-        "ERROR: Wrong argument count; expected {}, found {}!\n\nNOTE: This sometimes happens when you put the <ARG> argument specifier directly into the command as an argument.\n      If you did that, please specify an actual argument instead.\n      Passing <ARG> as a single self-contained argument without quotation marks (like this: please say <ARG> and <ARG>) to a command is considered a mistake on the user's side.\nExample: instead of\n<<VIO>> explain command <ARG>\n  please use\n<<VIO>> explain command help\n"
-    }
-}
+const ARGSPEC_MISUSED_ERROR_MESSAGE: &str =
+        "ERROR: <ARG> specifier used in a command directly as an argument!\n\nNOTE: please specify an actual argument instead.\nPassing <ARG> as a single self-contained argument without quotation marks (like this: please say <ARG> and <ARG>) to a command is considered a mistake on the user's side.\nExample: instead of\n<<VIO>> explain command <ARG>\n  please use\n<<VIO>> explain command help\n";
 
-const VIOLET_HELP_MESSAGE: &str = "Violet is a command interpreter.
+const VIOLET_HELP_MESSAGE: &str = "\n===HELP MESSAGE START===\nViolet is a command interpreter.
 When you see the \"<<VIO>> \" prompt, it means you can enter your command and press <ENTER>.
 ---
 Violet is going to try to interpret that command or let you know if it doesn't know such a command.
@@ -58,14 +55,14 @@ what, what is, what is your, what is your name => those are all \"nodes\".
 All nodes can be either null nodes or active nodes. When you add an alias for example, Violet creates several of such nodes. For example, if you:
 <<VIO>> add alias \"this is an alias for exit\" for builtin \"exit\"
 Violet creates the following nodes:
-- add => null node
-- add alias => null node
-- add alias <ARG> => null node
-- add alias <ARG> for => null node
-- add alias <ARG> for builtin => null node
-- add alias <ARG> for builtin <ARG> => active node, with value \"exit\"
-Null nodes are nodes that already exist and have path (such as \"add\" in the example), but their value is null (no value).
-Active nodes are nodes that exist, have value (such as \"add alias <ARG> for builtin <ARG>), and play an active role in Violet's operation. For example, from the point of adding the above active node, every time you invoke path \"this is an alias for exit\", Violet will invoke the \"exit\" command.
+- this => null node
+- this is => null node
+- this is an => null node
+- this is an alias => null node
+- this is an alias for => null node
+- this is an alias for exit => active node, with value \"exit\"
+Null nodes are nodes that already exist and have path (such as \"this\" in the example), but their value is null (no value).
+Active nodes are nodes that exist, have value (such as \"this is an alias for exit\" that has value \"exit\"), and play an active role in Violet's operation. For example, from the point of adding the above active node, every time you invoke path \"this is an alias for exit\", Violet will invoke the \"exit\" command.
 ---
 Violet has a command shortcut syntax. It works in the following way.
 The shortcut command itself is enclosed in [ and ].
@@ -93,7 +90,7 @@ is
 ---
 If the same shortcut is created several times due to name collision, the second and subsequent shortcuts are appended with a sequential number.
 Example:
-Assume we have three [eaa] commands, and they were added in this order:
+Assume we have three \"[eaa] <ARG>\" commands, and they were added in this order:
 1. enable alias <ARG>
 2. exists argument <ARG>
 3. eat ate <ARG>
@@ -120,7 +117,7 @@ Example: if you have two commands with the [eca] shortcut name, \"explain comman
 You can of course use shortcuts while meta-asking for explanation about explanation:
 <<VIO>> [eca] \"[eca] <ARG>\"
   [[help for explain command <ARG>]]
-";
+\n===HELP MESSAGE END===\n";
 
 pub struct Help;
 impl Help {
@@ -240,4 +237,8 @@ pub fn get_config_file_name() -> String {
 
 pub fn get_help_message() -> String {
     VIOLET_HELP_MESSAGE.to_string()
+}
+
+pub fn get_argspec_misused_error_message() -> String {
+  ARGSPEC_MISUSED_ERROR_MESSAGE.to_string()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -240,5 +240,5 @@ pub fn get_help_message() -> String {
 }
 
 pub fn get_argspec_misused_error_message() -> String {
-  ARGSPEC_MISUSED_ERROR_MESSAGE.to_string()
+    ARGSPEC_MISUSED_ERROR_MESSAGE.to_string()
 }

--- a/src/control/commands.rs
+++ b/src/control/commands.rs
@@ -20,7 +20,6 @@ pub enum InterpretedCommand {
 }
 
 pub enum InterpretationError {
-    WrongArgumentCount { expected: usize, actual: usize },
     ArgumentEmpty { argument_name: String },
 }
 
@@ -93,12 +92,6 @@ impl Action for WhatsYourNameCommand {
 pub struct SayThisAndThatCommand;
 impl Action for SayThisAndThatCommand {
     fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
-        if args.len() != 2 {
-            return Err(InterpretationError::WrongArgumentCount {
-                expected: 2,
-                actual: args.len(),
-            });
-        }
         println!(
             "Gotcha. Saying {} and {}!",
             args.get(0).unwrap(),
@@ -117,13 +110,6 @@ impl Action for SayThisAndThatCommand {
 pub struct AddAliasCommand;
 impl Action for AddAliasCommand {
     fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
-        if args.len() != 2 {
-            return Err(InterpretationError::WrongArgumentCount {
-                expected: 2,
-                actual: args.len(),
-            });
-        }
-
         if args[0].is_empty() {
             return Err(InterpretationError::ArgumentEmpty {
                 argument_name: "alias to add".to_string(),
@@ -150,13 +136,6 @@ impl Action for AddAliasCommand {
 pub struct RemoveAliasCommand;
 impl Action for RemoveAliasCommand {
     fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
-        if args.len() != 1 {
-            return Err(InterpretationError::WrongArgumentCount {
-                expected: 1,
-                actual: args.len(),
-            });
-        }
-
         if args[0].is_empty() {
             return Err(InterpretationError::ArgumentEmpty {
                 argument_name: "alias to remove".to_string(),
@@ -203,13 +182,6 @@ impl Action for ListAvailableCommandsCommand {
 pub struct ExplainCommandCommand;
 impl Action for ExplainCommandCommand {
     fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
-        if args.len() != 1 {
-            return Err(InterpretationError::WrongArgumentCount {
-                expected: 1,
-                actual: args.len(),
-            });
-        }
-
         if args[0].is_empty() {
             return Err(InterpretationError::ArgumentEmpty {
                 argument_name: "command to explain".to_string(),

--- a/src/control/commands.rs
+++ b/src/control/commands.rs
@@ -21,6 +21,7 @@ pub enum InterpretedCommand {
 
 pub enum InterpretationError {
     ArgumentEmpty { argument_name: String },
+    ArgSpecifierMisused,
 }
 
 #[enum_dispatch]
@@ -92,6 +93,10 @@ impl Action for WhatsYourNameCommand {
 pub struct SayThisAndThatCommand;
 impl Action for SayThisAndThatCommand {
     fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
+        if args.iter().any(|arg| arg == "<ARG>") {
+            return Err(InterpretationError::ArgSpecifierMisused);
+        }
+
         println!(
             "Gotcha. Saying {} and {}!",
             args.get(0).unwrap(),
@@ -110,6 +115,10 @@ impl Action for SayThisAndThatCommand {
 pub struct AddAliasCommand;
 impl Action for AddAliasCommand {
     fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
+        if args.iter().any(|arg| arg == "<ARG>") {
+            return Err(InterpretationError::ArgSpecifierMisused);
+        }
+
         if args[0].is_empty() {
             return Err(InterpretationError::ArgumentEmpty {
                 argument_name: "alias to add".to_string(),
@@ -136,6 +145,10 @@ impl Action for AddAliasCommand {
 pub struct RemoveAliasCommand;
 impl Action for RemoveAliasCommand {
     fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
+        if args.iter().any(|arg| arg == "<ARG>") {
+            return Err(InterpretationError::ArgSpecifierMisused);
+        }
+
         if args[0].is_empty() {
             return Err(InterpretationError::ArgumentEmpty {
                 argument_name: "alias to remove".to_string(),
@@ -182,6 +195,10 @@ impl Action for ListAvailableCommandsCommand {
 pub struct ExplainCommandCommand;
 impl Action for ExplainCommandCommand {
     fn execute(&self, args: Vec<String>) -> Result<InterpretedCommand, InterpretationError> {
+        if args.iter().any(|arg| arg == "<ARG>") {
+            return Err(InterpretationError::ArgSpecifierMisused);
+        }
+
         if args[0].is_empty() {
             return Err(InterpretationError::ArgumentEmpty {
                 argument_name: "command to explain".to_string(),

--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -240,9 +240,6 @@ impl Interpreter {
                                 .unwrap(),
                             args,
                         )
-                        .unwrap_or_else(|| {
-                            String::from("ERROR: keyword <ARG> used in the wrong context, or")
-                        })
                     } else {
                         user_input
                     }
@@ -270,6 +267,7 @@ impl Interpreter {
                             Ok(InterpretedCommand::RemoveAlias {alias}) => self.remove_alias(alias),
                             Ok(InterpretedCommand::ExplainCommand {command}) => self.explain_command(&command),
 
+                            Err(InterpretationError::ArgSpecifierMisused) => println!("{}", config::get_argspec_misused_error_message()),
                             Err(InterpretationError::ArgumentEmpty {argument_name}) => println!("ERROR: Argument named [{}] is empty, which is not allowed in this context!", argument_name),
                         }
                     } else {

--- a/src/control/interpreter.rs
+++ b/src/control/interpreter.rs
@@ -1,4 +1,3 @@
-use crate::argcount_err;
 use crate::config;
 use crate::data::pathtree::*;
 use crate::io::input;
@@ -271,7 +270,6 @@ impl Interpreter {
                             Ok(InterpretedCommand::RemoveAlias {alias}) => self.remove_alias(alias),
                             Ok(InterpretedCommand::ExplainCommand {command}) => self.explain_command(&command),
 
-                            Err(InterpretationError::WrongArgumentCount { expected, actual}) => println!(argcount_err!(), expected, actual),
                             Err(InterpretationError::ArgumentEmpty {argument_name}) => println!("ERROR: Argument named [{}] is empty, which is not allowed in this context!", argument_name),
                         }
                     } else {

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -261,7 +261,8 @@ where
                 &argumented,
                 TreePath::get_last_node(&path).unwrap().as_str(),
             ));
-            if self.does_node_exist(&argumented.join(" ")) && argumented.last().unwrap() == "<ARG>" {
+            if self.does_node_exist(&argumented.join(" ")) && argumented.last().unwrap() == "<ARG>"
+            {
                 args.push("<ARG>".to_owned());
                 continue;
             } else if self.does_node_exist(&argumented.join(" ")) {

--- a/src/data/pathtree.rs
+++ b/src/data/pathtree.rs
@@ -261,7 +261,10 @@ where
                 &argumented,
                 TreePath::get_last_node(&path).unwrap().as_str(),
             ));
-            if self.does_node_exist(&argumented.join(" ")) {
+            if self.does_node_exist(&argumented.join(" ")) && argumented.last().unwrap() == "<ARG>" {
+                args.push("<ARG>".to_owned());
+                continue;
+            } else if self.does_node_exist(&argumented.join(" ")) {
                 continue;
             } else {
                 let argified_from_previous = TreePath::append_path_node(&previous_state, "<ARG>");

--- a/src/util/treepath.rs
+++ b/src/util/treepath.rs
@@ -46,13 +46,10 @@ impl TreePath {
         args: Vec<String>,
     ) -> Option<String> {
         let mut pathvec = TreePath::create_path(path_to_reconstruct);
-        if pathvec
-            .iter()
-            .filter(|node| node.as_str() == "<ARG>")
-            .count()
-            != args.len()
+        let arg_count = TreePath::count_x_nodes_for_path(path_to_reconstruct, "<ARG>");
+        if arg_count != args.len()
         {
-            None
+            unreachable!(format!("TreePath::reconstruct_argumented_path(): actual number of arguments '{}' is not equal to the expected amount of '{}'", args.len(), arg_count));
         } else {
             let mut arg_index: usize = 0;
             for node in pathvec.iter_mut() {

--- a/src/util/treepath.rs
+++ b/src/util/treepath.rs
@@ -44,25 +44,20 @@ impl TreePath {
     pub fn reconstruct_argumented_path(
         path_to_reconstruct: &str,
         args: Vec<String>,
-    ) -> Option<String> {
+    ) -> String {
         let mut pathvec = TreePath::create_path(path_to_reconstruct);
-        let arg_count = TreePath::count_x_nodes_for_path(path_to_reconstruct, "<ARG>");
-        if arg_count != args.len()
-        {
-            unreachable!(format!("TreePath::reconstruct_argumented_path(): actual number of arguments '{}' is not equal to the expected amount of '{}'", args.len(), arg_count));
-        } else {
-            let mut arg_index: usize = 0;
-            for node in pathvec.iter_mut() {
-                if node.as_str() == "<ARG>" {
-                    let new_arg = format!("\"{}\"", args[arg_index]).to_string();
-                    *node = new_arg;
 
-                    arg_index += 1;
-                }
+        let mut arg_index: usize = 0;
+        for node in pathvec.iter_mut() {
+            if node.as_str() == "<ARG>" {
+                let new_arg = format!("\"{}\"", args[arg_index]).to_string();
+                *node = new_arg;
+
+                arg_index += 1;
             }
-
-            Some(pathvec.join(" "))
         }
+
+        pathvec.join(" ")
     }
 
     pub fn count_x_nodes_for_path(path: &str, x_node: &str) -> usize {

--- a/src/util/treepath.rs
+++ b/src/util/treepath.rs
@@ -41,10 +41,7 @@ impl TreePath {
         }
     }
 
-    pub fn reconstruct_argumented_path(
-        path_to_reconstruct: &str,
-        args: Vec<String>,
-    ) -> String {
+    pub fn reconstruct_argumented_path(path_to_reconstruct: &str, args: Vec<String>) -> String {
         let mut pathvec = TreePath::create_path(path_to_reconstruct);
 
         let mut arg_index: usize = 0;


### PR DESCRIPTION
- Removed the WrongArgumentCount error, introduced ArgSpecifierMisused error;
- Both aliases and builtins now behave the same way in relation to misusing the `<ARG>` specifier;
- Refactored `reconstruct_argumented_path()` to reflect the current situation;
- Fixed a couple error messages.